### PR TITLE
Tweak optimization options for examples

### DIFF
--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -24,3 +24,6 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+
+[profile.release]
+opt-level = "z"

--- a/erc1155/Cargo.toml
+++ b/erc1155/Cargo.toml
@@ -24,3 +24,6 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+
+[profile.release]
+opt-level = "z"

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -28,3 +28,6 @@ std = [
 ]
 ink-as-dependency = []
 e2e-tests = []
+
+[profile.release]
+opt-level = "z"

--- a/erc721/Cargo.toml
+++ b/erc721/Cargo.toml
@@ -24,3 +24,6 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+
+[profile.release]
+opt-level = "z"

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -24,3 +24,6 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+
+[profile.release]
+opt-level = "z"

--- a/trait-erc20/Cargo.toml
+++ b/trait-erc20/Cargo.toml
@@ -24,3 +24,6 @@ std = [
     "scale-info/std",
 ]
 ink-as-dependency = []
+
+[profile.release]
+opt-level = "z"


### PR DESCRIPTION
**!!!don't merge until** https://github.com/paritytech/cargo-contract/pull/1001 

[This data](https://github.com/paritytech/ink/pull/1702) shows that contracts changed in this PR end up in smaller wasm blob if optimized with `opt-level="z"`, which is not the default setting anymore since https://github.com/paritytech/cargo-contract/pull/1001