### PR TITLE
remove unstable runtime setting from call_runtime example docs

### DIFF
--- a/call-runtime/README.md
+++ b/call-runtime/README.md
@@ -13,7 +13,6 @@ To integrate this example into Substrate you need to adjust pallet contracts con
     …
     // `Everything` or anything that will allow for the `Balances::transfer` extrinsic.
     type CallFilter = frame_support::traits::Everything; 
-    type UnsafeUnstableInterface = ConstBool<true>;
     …
   }
   ```


### PR DESCRIPTION
once call_runtime is stabilized https://github.com/paritytech/ink/pull/1749, we don't need the `UnsafeUnstableInterface`