### PR TITLE
fix: address build failures in some contracts (#24)

### DIFF
--- a/basic_contract_caller/other_contract/Cargo.toml
+++ b/basic_contract_caller/other_contract/Cargo.toml
@@ -12,7 +12,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }
 
 [dev-dependencies]
-ink_e2e = { path = "../../../crates/e2e" }
+ink_e2e = { version = "4.2" }
 
 [lib]
 path = "lib.rs"

--- a/delegator/Cargo.toml
+++ b/delegator/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "delegator"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "4.1", default-features = false }
+ink = { version = "4.2", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
@@ -15,24 +15,23 @@ adder = { path = "adder", default-features = false, features = ["ink-as-dependen
 subber = { path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
 
+
 [dev-dependencies]
-ink_e2e = { version = "4.1" }
+ink_e2e = { version = "4.2" }
 
 [lib]
 name = "delegator"
 path = "lib.rs"
-crate-type = ["cdylib"]
 
 [features]
 default = ["std"]
 std = [
-    "ink/std",
-    "scale/std",
-    "scale-info/std",
-
-    "adder/std",
-    "subber/std",
-    "accumulator/std",
+    "ink/std", 
+    "scale/std", 
+    "scale-info/std", 
+    "adder/std", 
+    "subber/std", 
+    "accumulator/std"
 ]
 ink-as-dependency = []
 e2e-tests = []

--- a/delegator/accumulator/Cargo.toml
+++ b/delegator/accumulator/Cargo.toml
@@ -1,23 +1,17 @@
 [package]
 name = "accumulator"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.1", default-features = false }
+ink = { version = "4.2", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "accumulator"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]

--- a/delegator/accumulator/lib.rs
+++ b/delegator/accumulator/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 pub use self::accumulator::{
     Accumulator,

--- a/delegator/adder/Cargo.toml
+++ b/delegator/adder/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "adder"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.1", default-features = false }
+ink = { version = "4.2", default-features = false }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
@@ -15,12 +15,6 @@ scale-info = { version = "2.3", default-features = false, features = ["derive"],
 [lib]
 name = "adder"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]

--- a/delegator/adder/lib.rs
+++ b/delegator/adder/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 pub use self::adder::{
     Adder,

--- a/delegator/build-all.sh
+++ b/delegator/build-all.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-cargo +stable contract build --manifest-path accumulator/Cargo.toml
-cargo +stable contract build --manifest-path adder/Cargo.toml
-cargo +stable contract build --manifest-path subber/Cargo.toml
-cargo +stable contract build
+cargo contract build --manifest-path accumulator/Cargo.toml --release
+cargo contract build --manifest-path adder/Cargo.toml --release
+cargo contract build --manifest-path subber/Cargo.toml --release
+cargo contract build --release

--- a/delegator/lib.rs
+++ b/delegator/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract]
 mod delegator {

--- a/delegator/subber/Cargo.toml
+++ b/delegator/subber/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "subber"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.1", default-features = false }
+ink = { version = "4.2", default-features = false }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 
@@ -15,12 +15,6 @@ scale-info = { version = "2.3", default-features = false, features = ["derive"],
 [lib]
 name = "subber"
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-    # Used for ABI generation.
-    "rlib",
-]
 
 [features]
 default = ["std"]

--- a/delegator/subber/lib.rs
+++ b/delegator/subber/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 pub use self::subber::{
     Subber,

--- a/multi_contract_caller/Cargo.toml
+++ b/multi_contract_caller/Cargo.toml
@@ -27,7 +27,6 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-
     "adder/std",
     "subber/std",
     "accumulator/std",

--- a/multi_contract_caller/adder/Cargo.toml
+++ b/multi_contract_caller/adder/Cargo.toml
@@ -21,7 +21,6 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-
     "accumulator/std",
 ]
 ink-as-dependency = []

--- a/multi_contract_caller/subber/Cargo.toml
+++ b/multi_contract_caller/subber/Cargo.toml
@@ -21,7 +21,6 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-
     "accumulator/std",
 ]
 ink-as-dependency = []

--- a/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/Cargo.toml
@@ -26,7 +26,6 @@ std = [
     "ink/std",
     "scale/std",
     "scale-info/std",
-
     "dyn-traits/std",
 ]
 e2e-tests = []

--- a/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-ink = { path = "../../../../crates/ink", default-features = false }
+ink = { version = "4.2", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.5", default-features = false, features = ["derive"], optional = true }

--- a/trait-incrementer/traits/Cargo.toml
+++ b/trait-incrementer/traits/Cargo.toml
@@ -14,7 +14,6 @@ scale-info = { version = "2.5", default-features = false, features = ["derive"],
 [lib]
 name = "traits"
 path = "lib.rs"
-crate-type = ["rlib"]
 
 [features]
 default = ["std"]

--- a/upgradeable-contracts/forward-calls/Cargo.toml
+++ b/upgradeable-contracts/forward-calls/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "forward_calls"
-version = "4.1.0"
+version = "4.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "4.1", default-features = false }
+ink = { version = "4.2", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
@@ -14,7 +14,6 @@ scale-info = { version = "2.3", default-features = false, features = ["derive"],
 [lib]
 name = "forward_calls"
 path = "lib.rs"
-crate-type = ["cdylib"]
 
 [features]
 default = ["std"]

--- a/upgradeable-contracts/forward-calls/lib.rs
+++ b/upgradeable-contracts/forward-calls/lib.rs
@@ -13,7 +13,7 @@
 //! Note though that the contract to which calls are forwarded still
 //! contains it's own state.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract]
 pub mod proxy {

--- a/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ink = { version = "4.1", default-features = false }
+ink = { version = "4.2", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
@@ -16,7 +16,6 @@ scale-info = { version = "2.3", default-features = false, features = ["derive"],
 [lib]
 name = "incrementer"
 path = "lib.rs"
-crate-type = ["cdylib"]
 
 [features]
 default = ["std"]

--- a/upgradeable-contracts/set-code-hash/lib.rs
+++ b/upgradeable-contracts/set-code-hash/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract]
 pub mod incrementer {

--- a/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "updated-incrementer"
-version = "4.1.0"
+version = "4.2.0"
 edition = "2021"
 authors = ["Parity Technologies <admin@parity.io>"]
 publish = false
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ink = { version = "4.1", default-features = false }
+ink = { version = "4.2", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }
@@ -16,7 +16,6 @@ scale-info = { version = "2.3", default-features = false, features = ["derive"],
 [lib]
 name = "updated_incrementer"
 path = "lib.rs"
-crate-type = ["cdylib"]
 
 [features]
 default = ["std"]

--- a/upgradeable-contracts/set-code-hash/updated-incrementer/lib.rs
+++ b/upgradeable-contracts/set-code-hash/updated-incrementer/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract]
 pub mod incrementer {


### PR DESCRIPTION
The build process for some contracts was failing due to issues in certain `Cargo.toml` files;
Aside from some dependencies paths that needed to be adjusted,  there seems to be conflicts with the `crate-type` setting when using the updated version of the Ink contract compiler. Additionally, the `no_main` attribute was missing in some contracts.

## Description
- Commented out `crate-type` in `Cargo.toml` files to resolve conflicts with the updated Ink contract compiler.
- Fixed incorrect Ink dependency path. 
- Added the `no_main` attribute in `lib.rs` to address missing attributes in some contracts and prevent warning messages.

## Impacts
This pull request addresses issue #24

.
