### PR TITLE
Add workspace-enabled example contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     env:
       MULTI_CONTRACT_CALLER_SUBCONTRACTS: "accumulator adder subber"
       UPGRADEABLE_CONTRACTS: "delegator set-code-hash"
-      WORKSPACE_CONTRACTS: "erc20 flipper incrementer"
+      WORKSPACE_CONTRACTS: "erc20,flipper,incrementer"
       RUST_BACKTRACE: full
     steps:
       - name: Checkout sources & submodules
@@ -157,7 +157,8 @@ jobs:
         if: runner.os != 'Windows'
         run: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
 
-           for contract in $WORKSPACE_CONTRACTS; do
+           for contract in ${{ env.WORKSPACE_CONTRACTS }} 
+           do
                 echo "Processing workspace contract: $contract";
                 cargo ${{ matrix.job }} --verbose --manifest-path=workspace-contracts/$contract/Cargo.toml;
            done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
 
            for contract in ${{ env.WORKSPACE_CONTRACTS }} 
            do
-                echo "Processing workspace contract: $contract";
+                echo "Processing workspace contract: $contract "
                 cargo ${{ matrix.job }} --verbose --manifest-path=workspace-contracts/$contract/Cargo.toml;
            done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --git https://github.com/paritytech/cargo-contract.git --branch add-workspace-initial-support
+          args: --git https://github.com/paritytech/cargo-contract.git
 
       - name: Install cargo-dylint
         uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       MULTI_CONTRACT_CALLER_SUBCONTRACTS: "accumulator adder subber"
       UPGRADEABLE_CONTRACTS: "delegator set-code-hash"
+      WORKSPACE_CONTRACTS: "erc20 flipper incrementer"
       RUST_BACKTRACE: full
     steps:
 
@@ -55,7 +56,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: --git https://github.com/paritytech/cargo-contract.git
+          args: --git https://github.com/paritytech/cargo-contract.git --branch add-workspace-initial-support
 
       - name: Install cargo-dylint
         uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
@@ -111,6 +112,12 @@ jobs:
                cargo ${{ matrix.job }} --verbose --manifest-path upgradeable-contracts/${contract}/Cargo.toml;
            }
 
+           $workspace_contracts = "erc20","flipper","incrementer"
+           foreach ($contract in $workspace_contracts) {
+               echo "Processing workspace contract: $contract";
+               cargo ${{ matrix.job }} --verbose --manifest-path workspace-contracts/${contract}/Cargo.toml;
+           }
+
            foreach ($example in Get-ChildItem  -Directory "\*") {
                if ($example -Match 'artifacts') { continue }
                echo "Processing example: $example";
@@ -131,8 +138,13 @@ jobs:
                 cargo ${{ matrix.job }} --verbose --manifest-path=upgradeable-contracts/$contract/Cargo.toml;
            done
 
+           for contract in ${WORKSPACE_CONTRACTS}; do
+                echo "Processing workspace contract: $contract";
+                cargo ${{ matrix.job }} --verbose --manifest-path=workspace-contracts/$contract/Cargo.toml;
+           done
+
            for example in ./*/; do
-                if [ "$example" = "./artifacts/" ] || [ "$example" = "./upgradeable-contracts/" ]; then continue; fi;
+                if [ "$example" = "./artifacts/" ] || [ "$example" = "./upgradeable-contracts/" ]|| [ "$example" = "./workspace-contracts/" ]; then continue; fi;
                 echo "Processing example: $example";
                 cargo ${{ matrix.job }} --verbose --manifest-path=$example/Cargo.toml;
            done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     env:
       MULTI_CONTRACT_CALLER_SUBCONTRACTS: "accumulator adder subber"
       UPGRADEABLE_CONTRACTS: "delegator set-code-hash"
-      WORKSPACE_CONTRACTS: "erc20,flipper,incrementer"
+      WORKSPACE_CONTRACTS: "erc20 flipper incrementer"
       RUST_BACKTRACE: full
     steps:
       - name: Checkout sources & submodules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ on:
       - '.images/**'
       - '**README.md'
 
-
 jobs:
   check:
     name: examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,6 @@ jobs:
           unzip substrate-contracts-node.zip && \
           chmod +x artifacts/substrate-contracts-node-linux/substrate-contracts-node &&
           ./artifacts/substrate-contracts-node-linux/substrate-contracts-node -linfo,runtime::contracts=debug  2>&1 | tee /tmp/contracts-node.log &
-
       - name: Download and run latest `substrate-contracts-node` binary
         if: runner.os == 'macOS'
         run: |
@@ -121,18 +120,15 @@ jobs:
             unzip substrate-contracts-node.zip && \
             chmod +x artifacts/substrate-contracts-node-mac/substrate-contracts-node &&
             ./artifacts/substrate-contracts-node-mac/substrate-contracts-node -linfo,runtime::contracts=debug  2>&1 | tee /tmp/contracts-node.log &
-
       - name: Install and run latest `substrate-contracts-node` binary
         if: runner.os == 'Windows'
         run: |
             cargo install contracts-node --git https://github.com/paritytech/substrate-contracts-node.git --force --locked && \
             substrate-contracts-node -lruntime::contracts=debug  2>&1 | tee /tmp/contracts-node.log &
-
       - name: Output versions
         run: |
             cargo -vV
             cargo contract --version
-
       - name: Build ${{ matrix.contract }} examples on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os == 'Windows'
         run: |
@@ -141,31 +137,27 @@ jobs:
                echo "Processing multi-contract-caller contract: $contract";
                cargo ${{ matrix.job }} --verbose --manifest-path multi-contract-caller/${contract}/Cargo.toml;
            }
-
            $upgradeable_contracts = "delegator","set-code-hash"
            foreach ($contract in $upgradeable_contracts) {
                echo "Processing upgradeable contract: $contract";
                cargo ${{ matrix.job }} --verbose --manifest-path upgradeable-contracts/${contract}/Cargo.toml;
            }
-
            $workspace_contracts = "erc20","flipper","incrementer"
            foreach ($contract in $workspace_contracts) {
                echo "Processing workspace contract: $contract";
                cargo ${{ matrix.job }} --verbose --manifest-path workspace-contracts/${contract}/Cargo.toml;
            }
-
            foreach ($example in Get-ChildItem  -Directory "\*") {
                if ($example -Match 'artifacts') { continue }
                echo "Processing example: $example";
                cargo ${{ matrix.job }} --verbose --manifest-path=$example/Cargo.toml;
                cargo clean --manifest-path=$example/Cargo.toml;
            }
-
       - name: Build ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'
         run: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
 
-           for contract in ${WORKSPACE_CONTRACTS}; do
+           for contract in $WORKSPACE_CONTRACTS; do
                 echo "Processing workspace contract: $contract";
                 cargo ${{ matrix.job }} --verbose --manifest-path=workspace-contracts/$contract/Cargo.toml;
            done
@@ -179,4 +171,3 @@ jobs:
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'
         run: cargo test --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
-

--- a/workspace-contracts/.gitignore
+++ b/workspace-contracts/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/workspace-contracts/Cargo.toml
+++ b/workspace-contracts/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["*"]
+exclude = [".cargo", "target"]
+resolver = "2"
+
+[workspace.dependencies]
+ink = { version = "4.3.0", default-features = false }
+ink_e2e = "4.3.0"
+scale = { package = "parity-scale-codec", version = "=3.6.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"] }

--- a/workspace-contracts/erc20/Cargo.toml
+++ b/workspace-contracts/erc20/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "erc20"
+version = "4.3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { workspace = true }
+
+scale = { workspace = true, package = "parity-scale-codec" }
+scale-info = { workspace = true, optional = true }
+
+[dev-dependencies]
+ink_e2e = { workspace = true }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/workspace-contracts/erc20/lib.rs
+++ b/workspace-contracts/erc20/lib.rs
@@ -1,0 +1,675 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod erc20 {
+    use ink::storage::Mapping;
+
+    /// A simple ERC-20 contract.
+    #[ink(storage)]
+    #[derive(Default)]
+    pub struct Erc20 {
+        /// Total token supply.
+        total_supply: Balance,
+        /// Mapping from owner to number of owned token.
+        balances: Mapping<AccountId, Balance>,
+        /// Mapping of the token amount which an account is allowed to withdraw
+        /// from another account.
+        allowances: Mapping<(AccountId, AccountId), Balance>,
+    }
+
+    /// Event emitted when a token transfer occurs.
+    #[ink(event)]
+    pub struct Transfer {
+        #[ink(topic)]
+        from: Option<AccountId>,
+        #[ink(topic)]
+        to: Option<AccountId>,
+        value: Balance,
+    }
+
+    /// Event emitted when an approval occurs that `spender` is allowed to withdraw
+    /// up to the amount of `value` tokens from `owner`.
+    #[ink(event)]
+    pub struct Approval {
+        #[ink(topic)]
+        owner: AccountId,
+        #[ink(topic)]
+        spender: AccountId,
+        value: Balance,
+    }
+
+    /// The ERC-20 error types.
+    #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub enum Error {
+        /// Returned if not enough balance to fulfill a request is available.
+        InsufficientBalance,
+        /// Returned if not enough allowance to fulfill a request is available.
+        InsufficientAllowance,
+    }
+
+    /// The ERC-20 result type.
+    pub type Result<T> = core::result::Result<T, Error>;
+
+    impl Erc20 {
+        /// Creates a new ERC-20 contract with the specified initial supply.
+        #[ink(constructor)]
+        pub fn new(total_supply: Balance) -> Self {
+            let mut balances = Mapping::default();
+            let caller = Self::env().caller();
+            balances.insert(caller, &total_supply);
+            Self::env().emit_event(Transfer {
+                from: None,
+                to: Some(caller),
+                value: total_supply,
+            });
+            Self {
+                total_supply,
+                balances,
+                allowances: Default::default(),
+            }
+        }
+
+        /// Returns the total token supply.
+        #[ink(message)]
+        pub fn total_supply(&self) -> Balance {
+            self.total_supply
+        }
+
+        /// Returns the account balance for the specified `owner`.
+        ///
+        /// Returns `0` if the account is non-existent.
+        #[ink(message)]
+        pub fn balance_of(&self, owner: AccountId) -> Balance {
+            self.balance_of_impl(&owner)
+        }
+
+        /// Returns the account balance for the specified `owner`.
+        ///
+        /// Returns `0` if the account is non-existent.
+        ///
+        /// # Note
+        ///
+        /// Prefer to call this method over `balance_of` since this
+        /// works using references which are more efficient in Wasm.
+        #[inline]
+        fn balance_of_impl(&self, owner: &AccountId) -> Balance {
+            self.balances.get(owner).unwrap_or_default()
+        }
+
+        /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
+        ///
+        /// Returns `0` if no allowance has been set.
+        #[ink(message)]
+        pub fn allowance(&self, owner: AccountId, spender: AccountId) -> Balance {
+            self.allowance_impl(&owner, &spender)
+        }
+
+        /// Returns the amount which `spender` is still allowed to withdraw from `owner`.
+        ///
+        /// Returns `0` if no allowance has been set.
+        ///
+        /// # Note
+        ///
+        /// Prefer to call this method over `allowance` since this
+        /// works using references which are more efficient in Wasm.
+        #[inline]
+        fn allowance_impl(&self, owner: &AccountId, spender: &AccountId) -> Balance {
+            self.allowances.get((owner, spender)).unwrap_or_default()
+        }
+
+        /// Transfers `value` amount of tokens from the caller's account to account `to`.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the caller's account balance.
+        #[ink(message)]
+        pub fn transfer(&mut self, to: AccountId, value: Balance) -> Result<()> {
+            let from = self.env().caller();
+            self.transfer_from_to(&from, &to, value)
+        }
+
+        /// Allows `spender` to withdraw from the caller's account multiple times, up to
+        /// the `value` amount.
+        ///
+        /// If this function is called again it overwrites the current allowance with
+        /// `value`.
+        ///
+        /// An `Approval` event is emitted.
+        #[ink(message)]
+        pub fn approve(&mut self, spender: AccountId, value: Balance) -> Result<()> {
+            let owner = self.env().caller();
+            self.allowances.insert((&owner, &spender), &value);
+            self.env().emit_event(Approval {
+                owner,
+                spender,
+                value,
+            });
+            Ok(())
+        }
+
+        /// Transfers `value` tokens on the behalf of `from` to the account `to`.
+        ///
+        /// This can be used to allow a contract to transfer tokens on ones behalf and/or
+        /// to charge fees in sub-currencies, for example.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// # Errors
+        ///
+        /// Returns `InsufficientAllowance` error if there are not enough tokens allowed
+        /// for the caller to withdraw from `from`.
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the account balance of `from`.
+        #[ink(message)]
+        pub fn transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            value: Balance,
+        ) -> Result<()> {
+            let caller = self.env().caller();
+            let allowance = self.allowance_impl(&from, &caller);
+            if allowance < value {
+                return Err(Error::InsufficientAllowance)
+            }
+            self.transfer_from_to(&from, &to, value)?;
+            self.allowances
+                .insert((&from, &caller), &(allowance - value));
+            Ok(())
+        }
+
+        /// Transfers `value` amount of tokens from the caller's account to account `to`.
+        ///
+        /// On success a `Transfer` event is emitted.
+        ///
+        /// # Errors
+        ///
+        /// Returns `InsufficientBalance` error if there are not enough tokens on
+        /// the caller's account balance.
+        fn transfer_from_to(
+            &mut self,
+            from: &AccountId,
+            to: &AccountId,
+            value: Balance,
+        ) -> Result<()> {
+            let from_balance = self.balance_of_impl(from);
+            if from_balance < value {
+                return Err(Error::InsufficientBalance)
+            }
+
+            self.balances.insert(from, &(from_balance - value));
+            let to_balance = self.balance_of_impl(to);
+            self.balances.insert(to, &(to_balance + value));
+            self.env().emit_event(Transfer {
+                from: Some(*from),
+                to: Some(*to),
+                value,
+            });
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        use ink::primitives::{
+            Clear,
+            Hash,
+        };
+
+        type Event = <Erc20 as ::ink::reflect::ContractEventBase>::Type;
+
+        fn assert_transfer_event(
+            event: &ink::env::test::EmittedEvent,
+            expected_from: Option<AccountId>,
+            expected_to: Option<AccountId>,
+            expected_value: Balance,
+        ) {
+            let decoded_event = <Event as scale::Decode>::decode(&mut &event.data[..])
+                .expect("encountered invalid contract event data buffer");
+            if let Event::Transfer(Transfer { from, to, value }) = decoded_event {
+                assert_eq!(from, expected_from, "encountered invalid Transfer.from");
+                assert_eq!(to, expected_to, "encountered invalid Transfer.to");
+                assert_eq!(value, expected_value, "encountered invalid Trasfer.value");
+            } else {
+                panic!("encountered unexpected event kind: expected a Transfer event")
+            }
+            let expected_topics = vec![
+                encoded_into_hash(&PrefixedValue {
+                    value: b"Erc20::Transfer",
+                    prefix: b"",
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::from",
+                    value: &expected_from,
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::to",
+                    value: &expected_to,
+                }),
+                encoded_into_hash(&PrefixedValue {
+                    prefix: b"Erc20::Transfer::value",
+                    value: &expected_value,
+                }),
+            ];
+
+            let topics = event.topics.clone();
+            for (n, (actual_topic, expected_topic)) in
+                topics.iter().zip(expected_topics).enumerate()
+            {
+                let mut topic_hash = Hash::CLEAR_HASH;
+                let len = actual_topic.len();
+                topic_hash.as_mut()[0..len].copy_from_slice(&actual_topic[0..len]);
+
+                assert_eq!(
+                    topic_hash, expected_topic,
+                    "encountered invalid topic at {n}"
+                );
+            }
+        }
+
+        /// The default constructor does its job.
+        #[ink::test]
+        fn new_works() {
+            // Constructor works.
+            let _erc20 = Erc20::new(100);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        /// The total supply was applied.
+        #[ink::test]
+        fn total_supply_works() {
+            // Constructor works.
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Get the token total supply.
+            assert_eq!(erc20.total_supply(), 100);
+        }
+
+        /// Get the actual balance of an account.
+        #[ink::test]
+        fn balance_of_works() {
+            // Constructor works
+            let erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            // Alice owns all the tokens on contract instantiation
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            // Bob does not owns tokens
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+        }
+
+        #[ink::test]
+        fn transfer_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            // Alice transfers 10 tokens to Bob.
+            assert_eq!(erc20.transfer(accounts.bob, 10), Ok(()));
+            // Bob owns 10 tokens.
+            assert_eq!(erc20.balance_of(accounts.bob), 10);
+
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 2);
+            // Check first transfer event related to ERC-20 instantiation.
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // Check the second transfer event relating to the actual trasfer.
+            assert_transfer_event(
+                &emitted_events[1],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x02; 32])),
+                10,
+            );
+        }
+
+        #[ink::test]
+        fn invalid_transfer_should_fail() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+
+            // Set the contract as callee and Bob as caller.
+            let contract = ink::env::account_id::<ink::env::DefaultEnvironment>();
+            ink::env::test::set_callee::<ink::env::DefaultEnvironment>(contract);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+
+            // Bob fails to transfers 10 tokens to Eve.
+            assert_eq!(
+                erc20.transfer(accounts.eve, 10),
+                Err(Error::InsufficientBalance)
+            );
+            // Alice owns all the tokens.
+            assert_eq!(erc20.balance_of(accounts.alice), 100);
+            assert_eq!(erc20.balance_of(accounts.bob), 0);
+            assert_eq!(erc20.balance_of(accounts.eve), 0);
+
+            // Transfer event triggered during initial construction.
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 1);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+        }
+
+        #[ink::test]
+        fn transfer_from_works() {
+            // Constructor works.
+            let mut erc20 = Erc20::new(100);
+            // Transfer event triggered during initial construction.
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            // Bob fails to transfer tokens owned by Alice.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Err(Error::InsufficientAllowance)
+            );
+            // Alice approves Bob for token transfers on her behalf.
+            assert_eq!(erc20.approve(accounts.bob, 10), Ok(()));
+
+            // The approve event takes place.
+            assert_eq!(ink::env::test::recorded_events().count(), 2);
+
+            // Set the contract as callee and Bob as caller.
+            let contract = ink::env::account_id::<ink::env::DefaultEnvironment>();
+            ink::env::test::set_callee::<ink::env::DefaultEnvironment>(contract);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+
+            // Bob transfers tokens from Alice to Eve.
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, 10),
+                Ok(())
+            );
+            // Eve owns tokens.
+            assert_eq!(erc20.balance_of(accounts.eve), 10);
+
+            // Check all transfer events that happened during the previous calls:
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(emitted_events.len(), 3);
+            assert_transfer_event(
+                &emitted_events[0],
+                None,
+                Some(AccountId::from([0x01; 32])),
+                100,
+            );
+            // The second event `emitted_events[1]` is an Approve event that we skip
+            // checking.
+            assert_transfer_event(
+                &emitted_events[2],
+                Some(AccountId::from([0x01; 32])),
+                Some(AccountId::from([0x05; 32])),
+                10,
+            );
+        }
+
+        #[ink::test]
+        fn allowance_must_not_change_on_failed_transfer() {
+            let mut erc20 = Erc20::new(100);
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+
+            // Alice approves Bob for token transfers on her behalf.
+            let alice_balance = erc20.balance_of(accounts.alice);
+            let initial_allowance = alice_balance + 2;
+            assert_eq!(erc20.approve(accounts.bob, initial_allowance), Ok(()));
+
+            // Get contract address.
+            let callee = ink::env::account_id::<ink::env::DefaultEnvironment>();
+            ink::env::test::set_callee::<ink::env::DefaultEnvironment>(callee);
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+
+            // Bob tries to transfer tokens from Alice to Eve.
+            let emitted_events_before = ink::env::test::recorded_events().count();
+            assert_eq!(
+                erc20.transfer_from(accounts.alice, accounts.eve, alice_balance + 1),
+                Err(Error::InsufficientBalance)
+            );
+            // Allowance must have stayed the same
+            assert_eq!(
+                erc20.allowance(accounts.alice, accounts.bob),
+                initial_allowance
+            );
+            // No more events must have been emitted
+            assert_eq!(
+                emitted_events_before,
+                ink::env::test::recorded_events().count()
+            )
+        }
+
+        /// For calculating the event topic hash.
+        struct PrefixedValue<'a, 'b, T> {
+            pub prefix: &'a [u8],
+            pub value: &'b T,
+        }
+
+        impl<X> scale::Encode for PrefixedValue<'_, '_, X>
+        where
+            X: scale::Encode,
+        {
+            #[inline]
+            fn size_hint(&self) -> usize {
+                self.prefix.size_hint() + self.value.size_hint()
+            }
+
+            #[inline]
+            fn encode_to<T: scale::Output + ?Sized>(&self, dest: &mut T) {
+                self.prefix.encode_to(dest);
+                self.value.encode_to(dest);
+            }
+        }
+
+        fn encoded_into_hash<T>(entity: &T) -> Hash
+        where
+            T: scale::Encode,
+        {
+            use ink::{
+                env::hash::{
+                    Blake2x256,
+                    CryptoHash,
+                    HashOutput,
+                },
+                primitives::Clear,
+            };
+
+            let mut result = Hash::CLEAR_HASH;
+            let len_result = result.as_ref().len();
+            let encoded = entity.encode();
+            let len_encoded = encoded.len();
+            if len_encoded <= len_result {
+                result.as_mut()[..len_encoded].copy_from_slice(&encoded);
+                return result
+            }
+            let mut hash_output =
+                <<Blake2x256 as HashOutput>::Type as Default>::default();
+            <Blake2x256 as CryptoHash>::hash(&encoded, &mut hash_output);
+            let copy_len = core::cmp::min(hash_output.len(), len_result);
+            result.as_mut()[0..copy_len].copy_from_slice(&hash_output[0..copy_len]);
+            result
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::build_message;
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn e2e_transfer(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let total_supply = 1_000_000_000;
+            let constructor = Erc20Ref::new(total_supply);
+            let contract_acc_id = client
+                .instantiate("erc20", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // when
+            let total_supply_msg = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.total_supply());
+            let total_supply_res = client
+                .call_dry_run(&ink_e2e::bob(), &total_supply_msg, 0, None)
+                .await;
+
+            let bob_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Bob);
+            let transfer_to_bob = 500_000_000u128;
+            let transfer = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.transfer(bob_account.clone(), transfer_to_bob));
+            let _transfer_res = client
+                .call(&ink_e2e::alice(), transfer, 0, None)
+                .await
+                .expect("transfer failed");
+
+            let balance_of = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.balance_of(bob_account));
+            let balance_of_res = client
+                .call_dry_run(&ink_e2e::alice(), &balance_of, 0, None)
+                .await;
+
+            // then
+            assert_eq!(
+                total_supply,
+                total_supply_res.return_value(),
+                "total_supply"
+            );
+            assert_eq!(transfer_to_bob, balance_of_res.return_value(), "balance_of");
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn e2e_allowances(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let total_supply = 1_000_000_000;
+            let constructor = Erc20Ref::new(total_supply);
+            let contract_acc_id = client
+                .instantiate("erc20", &ink_e2e::bob(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // when
+
+            let bob_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Bob);
+            let charlie_account = ink_e2e::account_id(ink_e2e::AccountKeyring::Charlie);
+
+            let amount = 500_000_000u128;
+            let transfer_from =
+                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                    erc20.transfer_from(
+                        bob_account.clone(),
+                        charlie_account.clone(),
+                        amount,
+                    )
+                });
+            let transfer_from_result = client
+                .call(&ink_e2e::charlie(), transfer_from, 0, None)
+                .await;
+
+            assert!(
+                transfer_from_result.is_err(),
+                "unapproved transfer_from should fail"
+            );
+
+            // Bob approves Charlie to transfer up to amount on his behalf
+            let approved_value = 1_000u128;
+            let approve_call = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.approve(charlie_account.clone(), approved_value));
+            client
+                .call(&ink_e2e::bob(), approve_call, 0, None)
+                .await
+                .expect("approve failed");
+
+            // `transfer_from` the approved amount
+            let transfer_from =
+                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                    erc20.transfer_from(
+                        bob_account.clone(),
+                        charlie_account.clone(),
+                        approved_value,
+                    )
+                });
+            let transfer_from_result = client
+                .call(&ink_e2e::charlie(), transfer_from, 0, None)
+                .await;
+            assert!(
+                transfer_from_result.is_ok(),
+                "approved transfer_from should succeed"
+            );
+
+            let balance_of = build_message::<Erc20Ref>(contract_acc_id.clone())
+                .call(|erc20| erc20.balance_of(bob_account));
+            let balance_of_res = client
+                .call_dry_run(&ink_e2e::alice(), &balance_of, 0, None)
+                .await;
+
+            // `transfer_from` again, this time exceeding the approved amount
+            let transfer_from =
+                build_message::<Erc20Ref>(contract_acc_id.clone()).call(|erc20| {
+                    erc20.transfer_from(bob_account.clone(), charlie_account.clone(), 1)
+                });
+            let transfer_from_result = client
+                .call(&ink_e2e::charlie(), transfer_from, 0, None)
+                .await;
+            assert!(
+                transfer_from_result.is_err(),
+                "transfer_from exceeding the approved amount should fail"
+            );
+
+            assert_eq!(
+                total_supply - approved_value,
+                balance_of_res.return_value(),
+                "balance_of"
+            );
+
+            Ok(())
+        }
+    }
+}

--- a/workspace-contracts/flipper/Cargo.toml
+++ b/workspace-contracts/flipper/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "flipper"
+version = "4.3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { workspace = true }
+
+scale = { workspace = true, package = "parity-scale-codec" }
+scale-info = { workspace = true, optional = true }
+
+[dev-dependencies]
+ink_e2e = { workspace = true }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/workspace-contracts/flipper/lib.rs
+++ b/workspace-contracts/flipper/lib.rs
@@ -1,0 +1,115 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+pub mod flipper {
+    #[ink(storage)]
+    pub struct Flipper {
+        value: bool,
+    }
+
+    impl Flipper {
+        /// Creates a new flipper smart contract initialized with the given value.
+        #[ink(constructor)]
+        pub fn new(init_value: bool) -> Self {
+            Self { value: init_value }
+        }
+
+        /// Creates a new flipper smart contract initialized to `false`.
+        #[ink(constructor)]
+        pub fn new_default() -> Self {
+            Self::new(Default::default())
+        }
+
+        /// Flips the current value of the Flipper's boolean.
+        #[ink(message)]
+        pub fn flip(&mut self) {
+            self.value = !self.value;
+        }
+
+        /// Returns the current value of the Flipper's boolean.
+        #[ink(message)]
+        pub fn get(&self) -> bool {
+            self.value
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn default_works() {
+            let flipper = Flipper::new_default();
+            assert!(!flipper.get());
+        }
+
+        #[ink::test]
+        fn it_works() {
+            let mut flipper = Flipper::new(false);
+            assert!(!flipper.get());
+            flipper.flip();
+            assert!(flipper.get());
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::build_message;
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn it_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let constructor = FlipperRef::new(false);
+            let contract_acc_id = client
+                .instantiate("flipper", &ink_e2e::alice(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_res.return_value(), false));
+
+            // when
+            let flip = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.flip());
+            let _flip_res = client
+                .call(&ink_e2e::bob(), flip, 0, None)
+                .await
+                .expect("flip failed");
+
+            // then
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_res.return_value(), true));
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn default_works(mut client: ink_e2e::Client<C, E>) -> E2EResult<()> {
+            // given
+            let constructor = FlipperRef::new_default();
+
+            // when
+            let contract_acc_id = client
+                .instantiate("flipper", &ink_e2e::bob(), constructor, 0, None)
+                .await
+                .expect("instantiate failed")
+                .account_id;
+
+            // then
+            let get = build_message::<FlipperRef>(contract_acc_id.clone())
+                .call(|flipper| flipper.get());
+            let get_res = client.call_dry_run(&ink_e2e::bob(), &get, 0, None).await;
+            assert!(matches!(get_res.return_value(), false));
+
+            Ok(())
+        }
+    }
+}

--- a/workspace-contracts/incrementer/Cargo.toml
+++ b/workspace-contracts/incrementer/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "incrementer"
+version = "4.3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { workspace = true }
+
+scale = { workspace = true, package = "parity-scale-codec" }
+scale-info = { workspace = true, optional = true }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []

--- a/workspace-contracts/incrementer/lib.rs
+++ b/workspace-contracts/incrementer/lib.rs
@@ -1,0 +1,52 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod incrementer {
+    #[ink(storage)]
+    pub struct Incrementer {
+        value: i32,
+    }
+
+    impl Incrementer {
+        #[ink(constructor)]
+        pub fn new(init_value: i32) -> Self {
+            Self { value: init_value }
+        }
+
+        #[ink(constructor)]
+        pub fn new_default() -> Self {
+            Self::new(Default::default())
+        }
+
+        #[ink(message)]
+        pub fn inc(&mut self, by: i32) {
+            self.value += by;
+        }
+
+        #[ink(message)]
+        pub fn get(&self) -> i32 {
+            self.value
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[ink::test]
+        fn default_works() {
+            let contract = Incrementer::new_default();
+            assert_eq!(contract.get(), 0);
+        }
+
+        #[ink::test]
+        fn it_works() {
+            let mut contract = Incrementer::new(42);
+            assert_eq!(contract.get(), 42);
+            contract.inc(5);
+            assert_eq!(contract.get(), 47);
+            contract.inc(-50);
+            assert_eq!(contract.get(), -3);
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a workspace where dependencies are defined and several smart-contracts as part of the same workspace, with inherited dependencies.

It was created following the recommendation made in https://github.com/paritytech/cargo-contract/pull/1358. This should be merged after the mentioned PR is merged, given I had to force the branch version for running `cargo-contract` in the CI.

