### PR TITLE
CI optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,18 @@ on:
     tags:
         - v*
     paths-ignore:
-      - 'README.md'
-      - '.gitlab-ci.yml'
+      - '**.gitignore'
+      - '.images/**'
+      - '**README.md'
+
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.gitignore'
+      - '.images/**'
+      - '**README.md'
+
 
 jobs:
   check:
@@ -19,22 +26,45 @@ jobs:
     strategy:
       matrix:
         platform:
-          - ubuntu_20_64_core
+          - ubuntu-latest
           - macos-latest
         toolchain:
           - stable
-        job:
-          - contract build
-          - test
+        contract:
+          - basic-contract-caller
+          - call-runtime
+          - conditional-compilation
+          - contract-terminate
+          - custom-allocator
+          - custom-environment
+          - dns
+          - e2e-call-runtime
+          - erc20
+          - erc721
+          - erc1155
+          - flipper
+          - incrementer
+          - multi-contract-caller
+          - multi-contract-caller/accumulator
+          - multi-contract-caller/adder
+          - multi-contract-caller/subber
+          - multisig
+          - payment-channel
+          - psp22-extension
+          - rand-extension
+          - trait-dyn-cross-contract-calls
+          - trait-erc20
+          - trait-flipper
+          - trait-incrementer
+          - upgradeable-contracts/delegator
+          - upgradeable-contracts/set-code-hash
+          - vesting
     runs-on: ${{ matrix.platform }}
     env:
-      MULTI_CONTRACT_CALLER_SUBCONTRACTS: "accumulator adder subber"
-      UPGRADEABLE_CONTRACTS: "delegator set-code-hash"
       RUST_BACKTRACE: full
     steps:
-
       - name: Checkout sources & submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: recursive
@@ -49,22 +79,27 @@ jobs:
           override: true
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.2.0
+        uses: Swatinem/rust-cache@v2.7.0
+        with:
+          cache-on-failure: true
+          workspaces: ${{ matrix.contract }}
+          key: ${{ matrix.contract }}
 
       - name: Install `cargo-contract` `main`
-        uses: actions-rs/cargo@v1
+        uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941 # v2.2.0
         with:
-          command: install
-          args: --git https://github.com/paritytech/cargo-contract.git
+          crate: cargo-contract
+          git: https://github.com/paritytech/cargo-contract.git
+          cache-key: ${{ matrix.platform }}
 
       - name: Install cargo-dylint
-        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+        uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941 # v2.2.0
         with:
           crate: cargo-dylint
           version: 1
 
       - name: Install dylint-link
-        uses: baptiste0928/cargo-install@bf6758885262d0e6f61089a9d8c8790d3ac3368f # v1.3.0
+        uses: baptiste0928/cargo-install@21a18ba3bf4a184d1804e8b759930d3471b1c941 # v2.2.0
         with:
           crate: dylint-link
           version: 1
@@ -96,43 +131,10 @@ jobs:
             cargo -vV
             cargo contract --version
 
-      - name: ${{ matrix.job }} examples on ${{ matrix.platform }}-${{ matrix.toolchain }}
-        if: runner.os == 'Windows'
-        run: |
-           $multi_contract_caller_subcontracts = "accumulator","adder","subber"
-           foreach ($contract in $multi_contract_caller_subcontracts) {
-               echo "Processing multi-contract-caller contract: $contract";
-               cargo ${{ matrix.job }} --verbose --manifest-path multi-contract-caller/${contract}/Cargo.toml;
-           }
-
-           $upgradeable_contracts = "delegator","set-code-hash"
-           foreach ($contract in $upgradeable_contracts) {
-               echo "Processing upgradeable contract: $contract";
-               cargo ${{ matrix.job }} --verbose --manifest-path upgradeable-contracts/${contract}/Cargo.toml;
-           }
-
-           foreach ($example in Get-ChildItem  -Directory "\*") {
-               if ($example -Match 'artifacts') { continue }
-               echo "Processing example: $example";
-               cargo ${{ matrix.job }} --verbose --manifest-path=$example/Cargo.toml;
-               cargo clean --manifest-path=$example/Cargo.toml;
-           }
-
-      - name: ${{ matrix.job }} examples on ${{ matrix.platform }}-${{ matrix.toolchain }}
+      - name: Build ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'
-        run: |
-           for contract in ${MULTI_CONTRACT_CALLER_SUBCONTRACTS}; do
-               echo "Processing multi-contract-caller contract: $contract";
-               cargo ${{ matrix.job }} --verbose --manifest-path multi-contract-caller/${contract}/Cargo.toml;
-           done
+        run: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
 
-           for contract in ${UPGRADEABLE_CONTRACTS}; do
-                echo "Processing upgradeable contract: $contract";
-                cargo ${{ matrix.job }} --verbose --manifest-path=upgradeable-contracts/$contract/Cargo.toml;
-           done
-
-           for example in ./*/; do
-                if [ "$example" = "./artifacts/" ] || [ "$example" = "./upgradeable-contracts/" ]; then continue; fi;
-                echo "Processing example: $example";
-                cargo ${{ matrix.job }} --verbose --manifest-path=$example/Cargo.toml;
-           done
+      - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
+        if: runner.os != 'Windows'
+        run: cargo test --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;


### PR DESCRIPTION
This PR brings following optimizations to the CI:
1. Caching GHA's `Swatinem/rust-cache` was not configured properly therefore caching did not happen. This PR fixes it.
2. `cargo-contract` installation step also didn't use preferences of caching. Optimization in this PR leads to reduction of this step execution time from ~20min to [just few seconds](https://github.com/sergejparity/ink-examples/actions/runs/6513441131/job/17693070938).
3. Parallelises execution of the contracts examples build and tests which doubles workflow execution speed from ~3h to ~1.5h in case when [cache is not yet created](https://github.com/sergejparity/ink-examples/actions/runs/6509237909). And gives x6 speed boost when [cache already in place](https://github.com/sergejparity/ink-examples/actions/runs/6513441131)
4. Replaced expensive `ubuntu_20_64_core` runners with `ubuntu-latest`, keeping execution time at the same level (build and test against Ubuntu when cache is populated is 15-16min) and slightly slower without cache (25-30min). Related to https://github.com/paritytech/ci_cd/issues/553
5. Tuned `path-ignore` lists to not trigger CI if files like `README.md` and so on changed.