### PR TITLE
CI optimization: build workflow matrix dynamically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,47 +21,78 @@ on:
 
 
 jobs:
+  prepare_matrix:
+    name:
+    runs-on: ubuntu-latest
+    env:
+      # constant values for matrix
+      platform: '[\"ubuntu-latest\", \"macos-latest\"]'
+      toolchain: '[\"stable\"]'
+    outputs:
+      MATRIX: ${{ steps.build_matrix.outputs.MATRIX }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Look for changes in standalone contracts
+        id: CHANGED_CONTRACTS
+        uses: tj-actions/changed-files@v39
+        with:
+          dir_names: "true"
+          dir_names_max_depth: 1
+          files_ignore: |
+            .github/**
+            **.gitignore
+            *.md
+            multi-contract-caller/**
+            upgradeable-contracts/**
+          json: true
+
+      - name: Look for changes in multi and upgradable contracts
+        id: CHANGED_MULTI_AND_UPGRADEABLE_CONTRACTS
+        uses: tj-actions/changed-files@v39
+        with:
+          dir_names: "true"
+          dir_names_max_depth: 2
+          files: |
+            multi-contract-caller/**
+            upgradeable-contracts/**
+          files_ignore: |
+            **.gitignore
+            *.md
+          json: true
+
+      - name: Build matrix
+        id: build_matrix
+        run: |
+          ALL_CHANGED_CONTRACTS=$(jq -s 'add' \
+                                <(echo "${{ steps.CHANGED_CONTRACTS.outputs.all_changed_files }}") \
+                                <(echo "${{ steps.CHANGED_MULTI_AND_UPGRADEABLE_CONTRACTS.outputs.all_changed_files }}"))
+
+          echo "MATRIX={\"platform\":${{env.platform}},\
+                          \"toolchain\":${{env.toolchain}},\
+                          \"contract\":"$ALL_CHANGED_CONTRACTS"}"\
+                          >> $GITHUB_OUTPUT
+
+      - name: Show resulting matrix
+        run: |
+          echo "Following matrix will be used to generate test jobs."
+          echo ${{ toJson(steps.build_matrix.outputs.MATRIX) }} | jq
+
   check:
     name: examples
-    strategy:
-      matrix:
-        platform:
-          - ubuntu-latest
-          - macos-latest
-        toolchain:
-          - stable
-        contract:
-          - basic-contract-caller
-          - call-runtime
-          - conditional-compilation
-          - contract-terminate
-          - custom-allocator
-          - custom-environment
-          - dns
-          - e2e-call-runtime
-          - erc20
-          - erc721
-          - erc1155
-          - flipper
-          - incrementer
-          - multi-contract-caller
-          - multi-contract-caller/accumulator
-          - multi-contract-caller/adder
-          - multi-contract-caller/subber
-          - multisig
-          - payment-channel
-          - psp22-extension
-          - rand-extension
-          - trait-dyn-cross-contract-calls
-          - trait-erc20
-          - trait-flipper
-          - trait-incrementer
-          - upgradeable-contracts/delegator
-          - upgradeable-contracts/set-code-hash
-          - vesting
-    runs-on: ${{ matrix.platform }}
+    needs: prepare_matrix
     env:
       RUST_BACKTRACE: full
+
+    strategy:
+      matrix:
+        ${{ fromJson(needs.prepare_matrix.outputs.MATRIX) }}
+
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout sources & submodules
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - '**.gitignore'
       - '.images/**'
       - '**README.md'
+      - 'LICENSE'
 
   pull_request:
     branches:
@@ -18,6 +19,7 @@ on:
       - '**.gitignore'
       - '.images/**'
       - '**README.md'
+      - 'LICENSE'
 
 
 jobs:
@@ -30,6 +32,7 @@ jobs:
       toolchain: '[\"stable\"]'
     outputs:
       MATRIX: ${{ steps.build_matrix.outputs.MATRIX }}
+      SKIP_CHECKS: ${{ steps.build_matrix.outputs.SKIP_CHECKS }}
 
     steps:
       - name: Checkout
@@ -42,11 +45,12 @@ jobs:
         uses: tj-actions/changed-files@v39
         with:
           dir_names: "true"
+          dir_names_exclude_current_dir: "true"
           dir_names_max_depth: 1
           files_ignore: |
             .github/**
-            **.gitignore
-            *.md
+            **/.gitignore
+            **/*.md
             multi-contract-caller/**
             upgradeable-contracts/**
           json: true
@@ -56,13 +60,14 @@ jobs:
         uses: tj-actions/changed-files@v39
         with:
           dir_names: "true"
+          dir_names_exclude_current_dir: "true"
           dir_names_max_depth: 2
           files: |
             multi-contract-caller/**
             upgradeable-contracts/**
           files_ignore: |
-            **.gitignore
-            *.md
+            **/.gitignore
+            **/*.md
           json: true
 
       - name: Build matrix
@@ -71,6 +76,15 @@ jobs:
           ALL_CHANGED_CONTRACTS=$(jq -s 'add' \
                                 <(echo "${{ steps.CHANGED_CONTRACTS.outputs.all_changed_files }}") \
                                 <(echo "${{ steps.CHANGED_MULTI_AND_UPGRADEABLE_CONTRACTS.outputs.all_changed_files }}"))
+
+          if [ $ALL_CHANGED_CONTRACTS = "[]" ]
+          then
+            echo "Nothing important changed. Checks job will be skipped."
+            echo "SKIP_CHECKS=true" >> $GITHUB_OUTPUT
+          else
+            echo "There are changes in following contracts: $ALL_CHANGED_CONTRACTS"
+            echo "SKIP_CHECKS=false" >> $GITHUB_OUTPUT
+          fi
 
           echo "MATRIX={\"platform\":${{env.platform}},\
                           \"toolchain\":${{env.toolchain}},\
@@ -85,6 +99,7 @@ jobs:
   check:
     name: examples
     needs: prepare_matrix
+    if: ${{ needs.prepare_matrix.outputs.SKIP_CHECKS  == 'false' }}
     env:
       RUST_BACKTRACE: full
 


### PR DESCRIPTION
This PR brings even more optimisations to GHA workflow compared to https://github.com/paritytech/ink-examples/pull/45

Now I implemented dynamic matrix creation for the `check` job. It is looking for the PR changes and checks only changed contracts. This will speedup feedback loop even more than previous optimisation:

Also, there is no need  anymore to manually update list of the contracts in a workflow.

Example - PR touches 5 contracts:
[Without cache - ~44min](https://github.com/sergejparity/ink-examples/actions/runs/6549133357)
[With cache - ~7min](https://github.com/sergejparity/ink-examples/actions/runs/6552252427)

Related to https://github.com/paritytech/ci_cd/issues/553
