### PR TITLE
chore: ignore `./ui` folder as it does not contain contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
             **/*.md
             multi-contract-caller/**
             upgradeable-contracts/**
+            ui/**
           json: true
 
       - name: Look for changes in multi and upgradable contracts


### PR DESCRIPTION
fixes broken ci pipeline for newly included `ui` directory for frontend examples.