### PR TITLE
 Add workspace-enabled example contracts (was PR:#44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     outputs:
       MATRIX: ${{ steps.build_matrix.outputs.MATRIX }}
       SKIP_CHECKS: ${{ steps.build_matrix.outputs.SKIP_CHECKS }}
+      CHECK_WORKSPACE_CONTRACTS: ${{ step.build_matrix.outputs.CHECK_WORKSPACE_CONTRACTS }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
         if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
         run: |
           echo SHOULD WORK: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all --manifest-path=workspace-contracts/Cargo.toml
 
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,5 +227,6 @@ jobs:
       - name: Build workspace ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
         run: |
-          echo SHOULD WORK BUT #1172, #1265: cargo contract build --verbose --all --manifest-path=${{ matrix.contract }}/Cargo.toml
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all --manifest-path=workspace-contracts/Cargo.toml
+          echo FOLLOWING SEEMS TO WORK WITH CARGO-CONTRACT 4.0
+          cargo contract build --verbose --manifest-path=workspace-contracts/flipper/Cargo.toml
+          cargo contract build --verbose --manifest-path=workspace-contracts/incrementer/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
             echo "CHECK_WORKSPACE_CONTRACTS=false" >> $GITHUB_OUTPUT
             ALL_CHANGED_CONTRACTS=$(jq -s 'add' \
                                 <(echo "$ALL_CHANGED_CONTRACTS") \
-                                <(echo "[\"workspace-contracts\\flipper\", \"workspace-contracts\\incrementer\"]"))
+                                <(echo "[\"workspace-contracts/flipper\", \"workspace-contracts/incrementer\"]"))
             echo "AFTER: $ALL_CHANGED_CONTRACTS"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
     outputs:
       MATRIX: ${{ steps.build_matrix.outputs.MATRIX }}
       SKIP_CHECKS: ${{ steps.build_matrix.outputs.SKIP_CHECKS }}
-      CHECK_WORKSPACE_CONTRACTS: ${{ steps.build_matrix.outputs.CHECK_WORKSPACE_CONTRACTS }}
 
     steps:
       - name: Checkout
@@ -99,6 +98,19 @@ jobs:
                                 <(echo "${{ steps.CHANGED_CONTRACTS.outputs.all_changed_files }}") \
                                 <(echo "${{ steps.CHANGED_MULTI_AND_UPGRADEABLE_CONTRACTS.outputs.all_changed_files }}"))
 
+          if [ ${{steps.CHANGED_WORKSPACE_CONTRACTS}} = "[]" ]
+          then
+            echo "Nothing important changed. Workspace contracts job will be skipped."
+            echo "CHECK_WORKSPACE_CONTRACTS=true" >> $GITHUB_OUTPUT
+          else
+            echo "There are changes in following workspace-contracts: $ALL_CHANGED_CONTRACTS"
+            echo "CHECK_WORKSPACE_CONTRACTS=false" >> $GITHUB_OUTPUT
+            ALL_CHANGED_CONTRACTS=$(jq -s 'add' \
+                                <(echo "$ALL_CHANGED_CONTRACTS") \
+                                <(echo "[\"workspace-contracts\\flipper\", \"workspace-contracts\\incrementer\"]"))
+            echo "AFTER: $ALL_CHANGED_CONTRACTS"
+          fi
+
           if [ $ALL_CHANGED_CONTRACTS = "[]" ]
           then
             echo "Nothing important changed. Checks job will be skipped."
@@ -108,14 +120,6 @@ jobs:
             echo "SKIP_CHECKS=false" >> $GITHUB_OUTPUT
           fi
 
-          if [ ${{steps.CHANGED_WORKSPACE_CONTRACTS}} = "[]" ]
-          then
-            echo "Nothing important changed. Workspace contracts job will be skipped."
-            echo "CHECK_WORKSPACE_CONTRACTS=true" >> $GITHUB_OUTPUT
-          else
-            echo "There are changes in following workspace-contracts: ${{steps.CHANGED_WORKSPACE_CONTRACTS}}"
-            echo "CHECK_WORKSPACE_CONTRACTS=false" >> $GITHUB_OUTPUT
-          fi
 
           echo "MATRIX={\"platform\":${{env.platform}},\
                           \"toolchain\":${{env.toolchain}},\
@@ -130,7 +134,7 @@ jobs:
   check:
     name: examples
     needs: prepare_matrix
-    if: ${{ needs.prepare_matrix.outputs.SKIP_CHECKS  == 'false' }} || ${{ needs.prepare_matrix.outputs.CHECK_WORKSPACE_CONTRACTS  == 'true' }}
+    if: ${{ needs.prepare_matrix.outputs.SKIP_CHECKS  == 'false' }}
     env:
       RUST_BACKTRACE: full
 
@@ -209,16 +213,15 @@ jobs:
             cargo contract --version
 
       - name: Build ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && ${{ !startsWith(matrix.contract, 'workspace-contract') }}
         run: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
+
+      - name: Build workspace ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
+        if: runner.os != 'Windows' && ${{ startsWith(matrix.contract, 'workspace-contract') }}
+        run: |
+          echo SHOULD WORK: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
 
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'
         run: cargo test --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
-
-      - name: Build workspace-contracts on ${{ matrix.platform }}-${{ matrix.toolchain }}
-        if: runner.os != 'Windows' && ${{ needs.prepare_matrix.outputs.CHECK_WORKSPACE_CONTRACTS == 'false' }}
-        run: |
-          echo SHOULD WORK: cargo contract build --verbose --manifest-path={each contract in the workspace folder}/Cargo.toml;
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --manifest-path=workspace-contracts/flipper/Cargo.toml;
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --manifest-path=workspace-contracts/incrementer/Cargo.toml;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,9 +228,9 @@ jobs:
       - name: Build workspace ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
         run: |
-          echo SHOULD WORK: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
+          echo SHOULD WORK BUT #1172, #1265: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
           RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all --manifest-path=workspace-contracts/Cargo.toml
 
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.contract != 'workspace-contracts'
         run: cargo test --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,15 @@ jobs:
             upgradeable-contracts/**
           json: true
 
+
+      - name: List all changed files
+        run: |
+          echo " Changed workspace contracts " 
+          for file in ${{ steps.CHANGED_WORKSPACE_CONTRACTS.outputs.all_changed_files }}; do
+            echo "$file was changed"
+          done
+          echo "no more files.." 
+
       - name: Build matrix
         id: build_matrix
         run: |
@@ -98,7 +107,7 @@ jobs:
                                 <(echo "${{ steps.CHANGED_CONTRACTS.outputs.all_changed_files }}") \
                                 <(echo "${{ steps.CHANGED_MULTI_AND_UPGRADEABLE_CONTRACTS.outputs.all_changed_files }}"))
 
-          if [ ${{steps.CHANGED_WORKSPACE_CONTRACTS}} = "[]" ]
+          if [ ${{steps.CHANGED_WORKSPACE_CONTRACTS.outputs.all_changed_files }} = "[]" ]
           then
             echo "Nothing important changed. Workspace contracts job will be skipped."
             echo "CHECK_WORKSPACE_CONTRACTS=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,5 +227,5 @@ jobs:
       - name: Build workspace ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
         run: |
-          echo SHOULD WORK BUT #1172, #1265: cargo contract build --verbose --all --manifest-path=${{ matrix.contract }}/Cargo.toml; 
+          echo SHOULD WORK BUT #1172, #1265: cargo contract build --verbose --all --manifest-path=${{ matrix.contract }}/Cargo.toml
           RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all --manifest-path=workspace-contracts/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,22 @@ jobs:
             **/*.md
           json: true
 
+      - name: Look for changes in workspace contracts
+        id: CHANGED_WORKSPACE_CONTRACTS
+        uses: tj-actions/changed-files@v39
+        with:
+          dir_names: "true"
+          dir_names_exclude_current_dir: "true"
+          dir_names_max_depth: 2
+          files: |
+            workspace-contracts/**
+          files_ignore: |
+            **/.gitignore
+            **/*.md
+            multi-contract-caller/**
+            upgradeable-contracts/**
+          json: true
+
       - name: Build matrix
         id: build_matrix
         run: |
@@ -87,6 +103,15 @@ jobs:
           else
             echo "There are changes in following contracts: $ALL_CHANGED_CONTRACTS"
             echo "SKIP_CHECKS=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [ ${{steps.CHANGED_WORKSPACE_CONTRACTS}} = "[]" ]
+          then
+            echo "Nothing important changed. Workspace contracts job will be skipped."
+            echo "CHECK_WORKSPACE_CONTRACTS=true" >> $GITHUB_OUTPUT
+          else
+            echo "There are changes in following workspace-contracts: $ALL_CHANGED_CONTRACTS"
+            echo "CHECK_WORKSPACE_CONTRACTS=false" >> $GITHUB_OUTPUT
           fi
 
           echo "MATRIX={\"platform\":${{env.platform}},\
@@ -187,3 +212,10 @@ jobs:
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'
         run: cargo test --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
+
+      - name: Build workspace-contracts on ${{ matrix.platform }}-${{ matrix.toolchain }}
+        if: runner.os != 'Windows' && ${{ needs.prepare_matrix.outputs.CHECK_WORKSPACE_CONTRACTS == 'false' }}
+        run: |
+          echo SHOULD WORK: cargo contract build --verbose --manifest-path={each contract in the workspace folder}/Cargo.toml;
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --manifest-path=workspace-contracts/flipper/Cargo.toml;
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --manifest-path=workspace-contracts/incrementer/Cargo.toml;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
             **/*.md
             multi-contract-caller/**
             upgradeable-contracts/**
+            workspace-contracts/**
             ui/**
             **/frontend/**
           json: true
@@ -71,6 +72,7 @@ jobs:
           files_ignore: |
             **/.gitignore
             **/*.md
+            workspace-contracts/**
           json: true
 
       - name: Look for changes in workspace contracts
@@ -110,7 +112,7 @@ jobs:
             echo "Nothing important changed. Workspace contracts job will be skipped."
             echo "CHECK_WORKSPACE_CONTRACTS=true" >> $GITHUB_OUTPUT
           else
-            echo "There are changes in following workspace-contracts: $ALL_CHANGED_CONTRACTS"
+            echo "There are changes in following workspace-contracts: ${{steps.CHANGED_WORKSPACE_CONTRACTS}}"
             echo "CHECK_WORKSPACE_CONTRACTS=false" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,6 @@ jobs:
           files_ignore: |
             **/.gitignore
             **/*.md
-            multi-contract-caller/**
-            upgradeable-contracts/**
           json: true
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
             echo "Nothing important changed. Workspace contracts job will be skipped."
             echo "CHECK_WORKSPACE_CONTRACTS=true" >> $GITHUB_OUTPUT
           else
-            echo "There are changes in following workspace-contracts: $ALL_CHANGED_CONTRACTS"
             echo "CHECK_WORKSPACE_CONTRACTS=false" >> $GITHUB_OUTPUT
             ALL_CHANGED_CONTRACTS=$(jq -s 'add' \
                                 <(echo "$ALL_CHANGED_CONTRACTS") \
-                                <(echo "[\"workspace-contracts/flipper\", \"workspace-contracts/incrementer\"]"))
+                                <(echo "[\"workspace-contracts\"]"))
+            #                    <(echo "[\"workspace-contracts/flipper\", \"workspace-contracts/incrementer\"]"))
             echo "AFTER: $ALL_CHANGED_CONTRACTS"
           fi
 
@@ -222,14 +222,15 @@ jobs:
             cargo contract --version
 
       - name: Build ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
-        if: runner.os != 'Windows' && ${{ !startsWith(matrix.contract, 'workspace-contract') }}
+        if: runner.os != 'Windows' && matrix.contract != 'workspace-contracts'
         run: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
 
       - name: Build workspace ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
-        if: runner.os != 'Windows' && ${{ startsWith(matrix.contract, 'workspace-contract') }}
+        if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
         run: |
           echo SHOULD WORK: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --manifest-path=workspace-contracts/flipper/Cargo.toml;
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --manifest-path=workspace-contracts/incrementer/Cargo.toml;
 
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,8 +229,7 @@ jobs:
         if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
         run: |
           echo SHOULD WORK: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --manifest-path=workspace-contracts/flipper/Cargo.toml;
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --manifest-path=workspace-contracts/incrementer/Cargo.toml;
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all
 
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
   check:
     name: examples
     needs: prepare_matrix
-    if: ${{ needs.prepare_matrix.outputs.SKIP_CHECKS  == 'false' }}
+    if: ${{ needs.prepare_matrix.outputs.SKIP_CHECKS  == 'false' }} || ${{ needs.prepare_matrix.outputs.CHECK_WORKSPACE_CONTRACTS  == 'true' }}
     env:
       RUST_BACKTRACE: full
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,10 @@ jobs:
           if [ ${{steps.CHANGED_WORKSPACE_CONTRACTS.outputs.all_changed_files }} = "[]" ]
           then
             echo "Nothing important changed. Workspace contracts job will be skipped."
-            echo "CHECK_WORKSPACE_CONTRACTS=true" >> $GITHUB_OUTPUT
           else
-            echo "CHECK_WORKSPACE_CONTRACTS=false" >> $GITHUB_OUTPUT
             ALL_CHANGED_CONTRACTS=$(jq -s 'add' \
                                 <(echo "$ALL_CHANGED_CONTRACTS") \
                                 <(echo "[\"workspace-contracts\"]"))
-            #                    <(echo "[\"workspace-contracts/flipper\", \"workspace-contracts/incrementer\"]"))
-            echo "AFTER: $ALL_CHANGED_CONTRACTS"
           fi
 
           if [ $ALL_CHANGED_CONTRACTS = "[]" ]
@@ -128,7 +124,6 @@ jobs:
             echo "There are changes in following contracts: $ALL_CHANGED_CONTRACTS"
             echo "SKIP_CHECKS=false" >> $GITHUB_OUTPUT
           fi
-
 
           echo "MATRIX={\"platform\":${{env.platform}},\
                           \"toolchain\":${{env.toolchain}},\
@@ -225,12 +220,12 @@ jobs:
         if: runner.os != 'Windows' && matrix.contract != 'workspace-contracts'
         run: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
 
-      - name: Build workspace ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
-        if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
-        run: |
-          echo SHOULD WORK BUT #1172, #1265: cargo contract build --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
-          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all --manifest-path=workspace-contracts/Cargo.toml
-
       - name: Test ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
         if: runner.os != 'Windows' && matrix.contract != 'workspace-contracts'
         run: cargo test --verbose --manifest-path=${{ matrix.contract }}/Cargo.toml;
+
+      - name: Build workspace ${{ matrix.contract }} on ${{ matrix.platform }}-${{ matrix.toolchain }}
+        if: runner.os != 'Windows' && matrix.contract == 'workspace-contracts'
+        run: |
+          echo SHOULD WORK BUT #1172, #1265: cargo contract build --verbose --all --manifest-path=${{ matrix.contract }}/Cargo.toml; 
+          RUSTC_BOOTSTRAP=1 cargo build --target=wasm32-unknown-unknown -Zbuild-std=core,alloc --no-default-features --features ink/ink-debug --verbose --all --manifest-path=workspace-contracts/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       MATRIX: ${{ steps.build_matrix.outputs.MATRIX }}
       SKIP_CHECKS: ${{ steps.build_matrix.outputs.SKIP_CHECKS }}
-      CHECK_WORKSPACE_CONTRACTS: ${{ step.build_matrix.outputs.CHECK_WORKSPACE_CONTRACTS }}
+      CHECK_WORKSPACE_CONTRACTS: ${{ steps.build_matrix.outputs.CHECK_WORKSPACE_CONTRACTS }}
 
     steps:
       - name: Checkout

--- a/workspace-contracts/.gitignore
+++ b/workspace-contracts/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/workspace-contracts/Cargo.toml
+++ b/workspace-contracts/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = ["*"]
+exclude = [".cargo", "target"]
+resolver = "2"
+
+[workspace.dependencies]
+ink = { version = "4.3.0", default-features = false }
+ink_e2e = "4.3.0"
+scale = { package = "parity-scale-codec", version = "=3.6.5", default-features = false, features = ["derive"] }
+scale-info = { version = "2.6", default-features = false, features = ["derive"] }

--- a/workspace-contracts/flipper/Cargo.toml
+++ b/workspace-contracts/flipper/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "flipper"
+version = "4.3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { workspace = true }
+
+scale = { workspace = true, package = "parity-scale-codec" }
+scale-info = { workspace = true, optional = true }
+
+[dev-dependencies]
+ink_e2e = { workspace = true }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/workspace-contracts/flipper/lib.rs
+++ b/workspace-contracts/flipper/lib.rs
@@ -1,0 +1,35 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+pub mod flipper {
+    #[ink(storage)]
+    pub struct Flipper {
+        value: bool,
+    }
+
+    impl Flipper {
+        /// Creates a new flipper smart contract initialized with the given value.
+        #[ink(constructor)]
+        pub fn new(init_value: bool) -> Self {
+            Self { value: init_value }
+        }
+
+        /// Creates a new flipper smart contract initialized to `false`.
+        #[ink(constructor)]
+        pub fn new_default() -> Self {
+            Self::new(Default::default())
+        }
+
+        /// Flips the current value of the Flipper's boolean.
+        #[ink(message)]
+        pub fn flip(&mut self) {
+            self.value = !self.value;
+        }
+
+        /// Returns the current value of the Flipper's boolean.
+        #[ink(message)]
+        pub fn get(&self) -> bool {
+            self.value
+        }
+    }
+}

--- a/workspace-contracts/incrementer/Cargo.toml
+++ b/workspace-contracts/incrementer/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "incrementer"
+version = "4.3.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { workspace = true }
+
+scale = { workspace = true, package = "parity-scale-codec" }
+scale-info = { workspace = true, optional = true }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "scale/std",
+    "scale-info/std",
+]
+ink-as-dependency = []

--- a/workspace-contracts/incrementer/lib.rs
+++ b/workspace-contracts/incrementer/lib.rs
@@ -1,0 +1,31 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+mod incrementer {
+    #[ink(storage)]
+    pub struct Incrementer {
+        value: i32,
+    }
+
+    impl Incrementer {
+        #[ink(constructor)]
+        pub fn new(init_value: i32) -> Self {
+            Self { value: init_value }
+        }
+
+        #[ink(constructor)]
+        pub fn new_default() -> Self {
+            Self::new(Default::default())
+        }
+
+        #[ink(message)]
+        pub fn inc(&mut self, by: i32) {
+            self.value += by;
+        }
+
+        #[ink(message)]
+        pub fn get(&self) -> i32 {
+            self.value
+        }
+    }
+}

--- a/workspace-contracts/incrementer/lib.rs
+++ b/workspace-contracts/incrementer/lib.rs
@@ -20,7 +20,7 @@ mod incrementer {
 
         #[ink(message)]
         pub fn inc(&mut self, by: i32) {
-            self.value += by;
+            self.value = self.value.saturating_add(by);
         }
 
         #[ink(message)]


### PR DESCRIPTION
This PR creates a workspace where dependencies are defined and several smart-contracts as part of the same workspace, with inherited dependencies.

We tried different strategies on how to run the workspace contracts' build, and we chosen to try that build as a "whole" analogous to a contract in the test matrix.  The execution will be then cartesian product with the platforms.

Having the whole workspace-contracts in that way, we expect it to be all contracts in the workspace compiled at once.

We also included the suggestions given in the PR:44 before.

Was:
```
At the moment there are a few errors on cargo-contract preventing us to run it completely flawlessly, mainly : 
 * https://github.com/paritytech/cargo-contract/issues/1172
 * https://github.com/paritytech/cargo-contract/issues/1265
That is why we chosen to run the suggested build with `cargo build` instead. But left commented out what 
would be expected to be working in the future when above tickets get fixed.
```

Updated to:
Updated the CI/CD to what it should be: `cargo contract build ...` which will fail right now, but have no problems when the cargo-contract version is v 4.0 including: https://github.com/paritytech/cargo-contract/pull/1358 .



