### PR TITLE
Update to ink 5.0.0

### DIFF
--- a/basic-contract-caller/Cargo.toml
+++ b/basic-contract-caller/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "basic-contract-caller"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 # Note: We **need** to specify the `ink-as-dependency` feature.
 #
@@ -14,7 +14,7 @@ ink = { version = "5.0.0-rc.2", default-features = false }
 other-contract = { path = "other-contract", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/basic-contract-caller/other-contract/Cargo.toml
+++ b/basic-contract-caller/other-contract/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "other-contract"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/call-runtime/Cargo.toml
+++ b/call-runtime/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "call-runtime"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 # Substrate
 #
@@ -18,7 +18,7 @@ sp-io = { version = "23.0.0", default-features = false, features = ["disable_pan
 sp-runtime = { version = "24.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/combined-extension/Cargo.toml
+++ b/combined-extension/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "combined_extension"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 psp22_extension = { path = "../psp22-extension", default-features = false, features = ["ink-as-dependency"] }
 rand_extension = { path = "../rand-extension", default-features = false, features = ["ink-as-dependency"] }
 

--- a/conditional-compilation/Cargo.toml
+++ b/conditional-compilation/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "conditional-compilation"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/contract-storage/Cargo.toml
+++ b/contract-storage/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "contract-storage"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/contract-terminate/Cargo.toml
+++ b/contract-terminate/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "contract_terminate"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/contract-transfer/Cargo.toml
+++ b/contract-transfer/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "contract_transfer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/cross-contract-calls/Cargo.toml
+++ b/cross-contract-calls/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "cross-contract-calls"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 # Note: We **need** to specify the `ink-as-dependency` feature.
 #
@@ -14,7 +14,7 @@ ink = { version = "5.0.0-rc.2", default-features = false }
 other-contract = { path = "other-contract", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/cross-contract-calls/e2e_tests.rs
+++ b/cross-contract-calls/e2e_tests.rs
@@ -46,13 +46,13 @@ async fn instantiate_v2_with_insufficient_storage_deposit_limit<Client: E2EBacke
         .expect("other_contract upload failed");
 
     const REF_TIME_LIMIT: u64 = 500_000_000;
-    const PROOF_TIME_LIMIT: u64 = 100_000;
+    const PROOF_SIZE_LIMIT: u64 = 100_000;
     const STORAGE_DEPOSIT_LIMIT: u128 = 100_000_000_000;
 
     let mut constructor = CrossContractCallsRef::new_v2_with_limits(
         other_contract_code.code_hash,
         REF_TIME_LIMIT,
-        PROOF_TIME_LIMIT,
+        PROOF_SIZE_LIMIT,
         STORAGE_DEPOSIT_LIMIT,
     );
     let contract = client
@@ -87,13 +87,13 @@ async fn instantiate_v2_with_sufficient_limits<Client: E2EBackend>(
         .expect("other_contract upload failed");
 
     const REF_TIME_LIMIT: u64 = 500_000_000;
-    const PROOF_TIME_LIMIT: u64 = 100_000;
+    const PROOF_SIZE_LIMIT: u64 = 100_000;
     const STORAGE_DEPOSIT_LIMIT: u128 = 500_000_000_000;
 
     let mut constructor = CrossContractCallsRef::new_v2_with_limits(
         other_contract_code.code_hash,
         REF_TIME_LIMIT,
-        PROOF_TIME_LIMIT,
+        PROOF_SIZE_LIMIT,
         STORAGE_DEPOSIT_LIMIT,
     );
     let contract = client
@@ -147,13 +147,13 @@ async fn flip_and_get_v2<Client: E2EBackend>(mut client: Client) -> E2EResult<()
     let mut call_builder = contract.call_builder::<CrossContractCalls>();
 
     const REF_TIME_LIMIT: u64 = 500_000_000;
-    const PROOF_TIME_LIMIT: u64 = 100_000;
+    const PROOF_SIZE_LIMIT: u64 = 100_000;
     const STORAGE_DEPOSIT_LIMIT: u128 = 1_000_000_000;
 
     // when
     let call = call_builder.flip_and_get_invoke_v2_with_limits(
         REF_TIME_LIMIT,
-        PROOF_TIME_LIMIT,
+        PROOF_SIZE_LIMIT,
         STORAGE_DEPOSIT_LIMIT,
     );
     let result = client

--- a/cross-contract-calls/lib.rs
+++ b/cross-contract-calls/lib.rs
@@ -18,7 +18,7 @@ mod cross_contract_calls {
         pub fn new_v2_with_limits(
             other_contract_code_hash: Hash,
             ref_time_limit: u64,
-            proof_time_limit: u64,
+            proof_size_limit: u64,
             storage_deposit_limit: Balance,
         ) -> Self {
             let other_contract = OtherContractRef::new(true)
@@ -26,7 +26,7 @@ mod cross_contract_calls {
                 .endowment(0)
                 .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
                 .ref_time_limit(ref_time_limit)
-                .proof_time_limit(proof_time_limit)
+                .proof_size_limit(proof_size_limit)
                 .storage_deposit_limit(storage_deposit_limit)
                 .instantiate();
 
@@ -82,7 +82,7 @@ mod cross_contract_calls {
         pub fn flip_and_get_invoke_v2_with_limits(
             &mut self,
             ref_time_limit: u64,
-            proof_time_limit: u64,
+            proof_size_limit: u64,
             storage_deposit_limit: Balance,
         ) -> bool {
             let call_builder = self.other_contract.call_mut();
@@ -90,14 +90,14 @@ mod cross_contract_calls {
             call_builder
                 .flip()
                 .ref_time_limit(ref_time_limit)
-                .proof_time_limit(proof_time_limit)
+                .proof_size_limit(proof_size_limit)
                 .storage_deposit_limit(storage_deposit_limit)
                 .invoke();
 
             call_builder
                 .get()
                 .ref_time_limit(ref_time_limit)
-                .proof_time_limit(proof_time_limit)
+                .proof_size_limit(proof_size_limit)
                 .storage_deposit_limit(storage_deposit_limit)
                 .invoke()
         }

--- a/cross-contract-calls/other-contract/Cargo.toml
+++ b/cross-contract-calls/other-contract/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "other-contract"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/custom-allocator/Cargo.toml
+++ b/custom-allocator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "custom-allocator"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
@@ -8,13 +8,13 @@ publish = false
 [dependencies]
 # We're going to use a different allocator than the one provided by ink!. To do that we
 # first need to disable the included memory allocator.
-ink = { version = "5.0.0-rc.2", default-features = false, features = ["no-allocator"]  }
+ink = { version = "5.0.0", default-features = false, features = ["no-allocator"]  }
 
 # This is going to be our new global memory allocator.
 dlmalloc = {version = "0.2", default-features = false, features = ["global"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/custom-environment/Cargo.toml
+++ b/custom-environment/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "custom-environment"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "dns"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/e2e-call-runtime/Cargo.toml
+++ b/e2e-call-runtime/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "e2e_call_runtime"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/e2e-runtime-only-backend/.gitignore
+++ b/e2e-runtime-only-backend/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/e2e-runtime-only-backend/Cargo.toml
+++ b/e2e-runtime-only-backend/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "e2e-runtime-only-backend"
+version = "5.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { version = "5.0.0", default-features = false }
+
+[dev-dependencies]
+ink_e2e = { version = "5.0.0" }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]
+ink-as-dependency = []
+e2e-tests = []

--- a/e2e-runtime-only-backend/lib.rs
+++ b/e2e-runtime-only-backend/lib.rs
@@ -1,0 +1,165 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::contract]
+pub mod flipper {
+    #[ink(storage)]
+    pub struct Flipper {
+        value: bool,
+    }
+
+    impl Flipper {
+        /// Creates a new flipper smart contract initialized with the given value.
+        #[ink(constructor)]
+        pub fn new(init_value: bool) -> Self {
+            Self { value: init_value }
+        }
+
+        /// Creates a new flipper smart contract initialized to `false`.
+        #[ink(constructor)]
+        pub fn new_default() -> Self {
+            Self::new(Default::default())
+        }
+
+        /// Flips the current value of the Flipper's boolean.
+        #[ink(message)]
+        pub fn flip(&mut self) {
+            self.value = !self.value;
+        }
+
+        /// Returns the current value of the Flipper's boolean.
+        #[ink(message)]
+        pub fn get(&self) -> bool {
+            self.value
+        }
+
+        /// Returns the current balance of the Flipper.
+        #[ink(message)]
+        pub fn get_contract_balance(&self) -> Balance {
+            self.env().balance()
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::{
+            subxt::dynamic::Value,
+            ChainBackend,
+            ContractsBackend,
+        };
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        /// Tests standard flipper scenario:
+        /// - deploy the flipper contract with initial value `false`
+        /// - flip the flipper
+        /// - get the flipper's value
+        /// - assert that the value is `true`
+        #[ink_e2e::test(backend(runtime_only))]
+        async fn it_works<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+            // given
+            const INITIAL_VALUE: bool = false;
+            let mut constructor = FlipperRef::new(INITIAL_VALUE);
+
+            let contract = client
+                .instantiate(
+                    "e2e-runtime-only-backend",
+                    &ink_e2e::alice(),
+                    &mut constructor,
+                )
+                .submit()
+                .await
+                .expect("deploy failed");
+
+            // when
+            let mut call_builder = contract.call_builder::<Flipper>();
+            let _flip_res = client
+                .call(&ink_e2e::bob(), &call_builder.flip())
+                .submit()
+                .await;
+
+            // then
+            let get_res = client
+                .call(&ink_e2e::bob(), &call_builder.get())
+                .dry_run()
+                .await?;
+            assert_eq!(get_res.return_value(), !INITIAL_VALUE);
+
+            Ok(())
+        }
+
+        /// Tests runtime call scenario:
+        /// - deploy the flipper contract
+        /// - get the contract's balance
+        /// - transfer some funds to the contract using runtime call
+        /// - get the contract's balance again
+        /// - assert that the contract's balance increased by the transferred amount
+        #[ink_e2e::test(backend(runtime_only))]
+        async fn runtime_call_works() -> E2EResult<()> {
+            // given
+            let mut constructor = FlipperRef::new(false);
+
+            let contract = client
+                .instantiate(
+                    "e2e-runtime-only-backend",
+                    &ink_e2e::alice(),
+                    &mut constructor,
+                )
+                .submit()
+                .await
+                .expect("deploy failed");
+            let call_builder = contract.call_builder::<Flipper>();
+
+            let old_balance = client
+                .call(&ink_e2e::alice(), &call_builder.get_contract_balance())
+                .submit()
+                .await
+                .expect("get_contract_balance failed")
+                .return_value();
+
+            const ENDOWMENT: u128 = 10;
+
+            // when
+            let call_data = vec![
+                Value::unnamed_variant("Id", [Value::from_bytes(contract.account_id)]),
+                Value::u128(ENDOWMENT),
+            ];
+            client
+                .runtime_call(
+                    &ink_e2e::alice(),
+                    "Balances",
+                    "transfer_allow_death",
+                    call_data,
+                )
+                .await
+                .expect("runtime call failed");
+
+            // then
+            let new_balance = client
+                .call(&ink_e2e::alice(), &call_builder.get_contract_balance())
+                .submit()
+                .await
+                .expect("get_contract_balance failed")
+                .return_value();
+
+            assert_eq!(old_balance + ENDOWMENT, new_balance);
+            Ok(())
+        }
+
+        /// Just instantiate a contract using non-default runtime.
+        #[ink_e2e::test(backend(runtime_only(sandbox = ink_e2e::MinimalSandbox)))]
+        async fn custom_runtime<Client: E2EBackend>(mut client: Client) -> E2EResult<()> {
+            client
+                .instantiate(
+                    "e2e-runtime-only-backend",
+                    &ink_e2e::alice(),
+                    &mut FlipperRef::new(false),
+                )
+                .submit()
+                .await
+                .expect("instantiate failed");
+
+            Ok(())
+        }
+    }
+}

--- a/erc1155/Cargo.toml
+++ b/erc1155/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "erc1155"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "erc20"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/erc721/Cargo.toml
+++ b/erc721/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "erc721"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/events/.gitignore
+++ b/events/.gitignore
@@ -1,0 +1,9 @@
+# Ignore build artifacts from the local tests sub-crate.
+/target/
+
+# Ignore backup files creates by cargo fmt.
+**/*.rs.bk
+
+# Remove Cargo.lock when creating an executable, leave it for libraries
+# More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
+Cargo.lock

--- a/events/Cargo.toml
+++ b/events/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "events"
+version = "5.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+ink = { version = "5.0.0", default-features = false }
+
+event-def = { path = "event-def", default-features = false }
+event-def2 = { path = "event-def2", default-features = false }
+event-def-unused = { path = "event-def-unused", default-features = false }
+
+[dev-dependencies]
+ink_e2e = { version = "5.0.0" }
+
+[lib]
+path = "lib.rs"
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+    "event-def/std",
+    "event-def2/std",
+    "event-def-unused/std",
+]
+ink-as-dependency = []
+e2e-tests = []
+
+[profile.test]
+# Need this for linkme crate to work for the event metadata unit test.
+# See https://github.com/dtolnay/linkme/issues/61#issuecomment-1503653702
+lto = "thin"

--- a/events/event-def-unused/Cargo.toml
+++ b/events/event-def-unused/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "event-def-unused"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ink = { version = "5.0.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]

--- a/events/event-def-unused/src/lib.rs
+++ b/events/event-def-unused/src/lib.rs
@@ -1,0 +1,15 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::trait_definition]
+pub trait FlipperTrait {
+    #[ink(message)]
+    fn flip(&mut self);
+}
+
+#[ink::event]
+pub struct EventDefUnused {
+    #[ink(topic)]
+    pub hash: [u8; 32],
+    #[ink(topic)]
+    pub maybe_hash: Option<[u8; 32]>,
+}

--- a/events/event-def/Cargo.toml
+++ b/events/event-def/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "event-def"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ink = { version = "5.0.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]

--- a/events/event-def/src/lib.rs
+++ b/events/event-def/src/lib.rs
@@ -1,0 +1,14 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::event]
+pub struct ForeignFlipped {
+    pub value: bool,
+}
+
+#[ink::event]
+pub struct ThirtyTwoByteTopics {
+    #[ink(topic)]
+    pub hash: [u8; 32],
+    #[ink(topic)]
+    pub maybe_hash: Option<[u8; 32]>,
+}

--- a/events/event-def2/Cargo.toml
+++ b/events/event-def2/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "event-def2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ink = { version = "5.0.0", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "ink/std",
+]

--- a/events/event-def2/src/lib.rs
+++ b/events/event-def2/src/lib.rs
@@ -1,0 +1,9 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::event]
+pub struct EventDefAnotherCrate {
+    #[ink(topic)]
+    pub hash: [u8; 32],
+    #[ink(topic)]
+    pub maybe_hash: Option<[u8; 32]>,
+}

--- a/events/lib.rs
+++ b/events/lib.rs
@@ -1,0 +1,415 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+#[ink::event(anonymous)]
+pub struct AnonymousEvent {
+    #[ink(topic)]
+    pub topic: [u8; 32],
+    pub field_1: u32,
+}
+
+#[ink::contract]
+pub mod events {
+    #[ink(storage)]
+    pub struct Events {
+        value: bool,
+    }
+
+    #[ink(event)]
+    pub struct InlineFlipped {
+        value: bool,
+    }
+
+    #[ink(
+        event,
+        signature_topic = "1111111111111111111111111111111111111111111111111111111111111111"
+    )]
+    pub struct InlineCustomFlipped {
+        value: bool,
+    }
+
+    #[ink(event)]
+    #[ink(anonymous)]
+    pub struct InlineAnonymousEvent {
+        #[ink(topic)]
+        pub topic: [u8; 32],
+        pub field_1: u32,
+    }
+
+    impl Events {
+        /// Creates a new events smart contract initialized with the given value.
+        #[ink(constructor)]
+        pub fn new(init_value: bool) -> Self {
+            Self { value: init_value }
+        }
+
+        /// Flips the current value of the boolean.
+        #[ink(message)]
+        pub fn flip_with_foreign_event(&mut self) {
+            self.value = !self.value;
+            self.env()
+                .emit_event(event_def::ForeignFlipped { value: self.value })
+        }
+
+        /// Flips the current value of the boolean.
+        #[ink(message)]
+        pub fn flip_with_inline_event(&mut self) {
+            self.value = !self.value;
+            self.env().emit_event(InlineFlipped { value: self.value })
+        }
+
+        /// Flips the current value of the boolean.
+        #[ink(message)]
+        pub fn flip_with_inline_custom_event(&mut self) {
+            self.value = !self.value;
+            self.env()
+                .emit_event(InlineCustomFlipped { value: self.value })
+        }
+
+        /// Emit an event with a 32 byte topic.
+        #[ink(message)]
+        pub fn emit_32_byte_topic_event(&self, maybe_hash: Option<[u8; 32]>) {
+            self.env().emit_event(event_def::ThirtyTwoByteTopics {
+                hash: [0x42; 32],
+                maybe_hash,
+            })
+        }
+
+        /// Emit an event from a different crate.
+        #[ink(message)]
+        pub fn emit_event_from_a_different_crate(&self, maybe_hash: Option<[u8; 32]>) {
+            self.env().emit_event(event_def2::EventDefAnotherCrate {
+                hash: [0x42; 32],
+                maybe_hash,
+            })
+        }
+
+        /// Emit a inline and standalone anonymous events
+        #[ink(message)]
+        pub fn emit_anonymous_events(&self, topic: [u8; 32]) {
+            self.env()
+                .emit_event(InlineAnonymousEvent { topic, field_1: 42 });
+            self.env()
+                .emit_event(super::AnonymousEvent { topic, field_1: 42 });
+        }
+    }
+
+    /// Implementing the trait from the `event_def_unused` crate includes all defined
+    /// events there.
+    impl event_def_unused::FlipperTrait for Events {
+        #[ink(message)]
+        fn flip(&mut self) {
+            self.value = !self.value;
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use ink::scale::Decode as _;
+
+        #[test]
+        fn collects_specs_for_all_linked_and_used_events() {
+            let event_specs = ink::metadata::collect_events();
+            assert_eq!(8, event_specs.len());
+
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"ForeignFlipped"));
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"InlineFlipped"));
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"InlineCustomFlipped"));
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"ThirtyTwoByteTopics"));
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"EventDefAnotherCrate"));
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"AnonymousEvent"));
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"InlineAnonymousEvent"));
+
+            // The event is not used in the code by being included in the metadata
+            // because we implement trait form `event_def_unused` crate.
+            assert!(event_specs
+                .iter()
+                .any(|evt| evt.label() == &"EventDefUnused"));
+        }
+
+        #[ink::test]
+        fn it_works() {
+            let mut events = Events::new(false);
+            events.flip_with_foreign_event();
+
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+            let event = &emitted_events[0];
+
+            let decoded_event = <event_def::ForeignFlipped>::decode(&mut &event.data[..])
+                .expect("encountered invalid contract event data buffer");
+            assert!(decoded_event.value);
+        }
+
+        #[ink::test]
+        fn option_topic_some_has_topic() {
+            let events = Events::new(false);
+            events.emit_32_byte_topic_event(Some([0xAA; 32]));
+
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+            let event = &emitted_events[0];
+
+            assert_eq!(event.topics.len(), 3);
+            let signature_topic =
+                <event_def::ThirtyTwoByteTopics as ink::env::Event>::SIGNATURE_TOPIC
+                    .map(|topic| topic.to_vec());
+            assert_eq!(Some(&event.topics[0]), signature_topic.as_ref());
+            assert_eq!(event.topics[1], [0x42; 32]);
+            assert_eq!(
+                event.topics[2], [0xAA; 32],
+                "option topic should be published"
+            );
+        }
+
+        #[ink::test]
+        fn option_topic_none_encoded_as_0() {
+            let events = Events::new(false);
+            events.emit_32_byte_topic_event(None);
+
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+            let event = &emitted_events[0];
+
+            let signature_topic =
+                <event_def::ThirtyTwoByteTopics as ink::env::Event>::SIGNATURE_TOPIC
+                    .map(|topic| topic.to_vec())
+                    .unwrap();
+
+            let expected_topics = vec![
+                signature_topic,
+                [0x42; 32].to_vec(),
+                [0x00; 32].to_vec(), // None is encoded as 0x00
+            ];
+            assert_eq!(expected_topics, event.topics);
+        }
+
+        #[ink::test]
+        fn custom_signature_topic() {
+            let mut events = Events::new(false);
+            events.flip_with_inline_custom_event();
+
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(1, emitted_events.len());
+
+            let signature_topic =
+                <InlineCustomFlipped as ink::env::Event>::SIGNATURE_TOPIC;
+
+            assert_eq!(Some([17u8; 32]), signature_topic);
+        }
+
+        #[ink::test]
+        fn anonymous_events_emit_no_signature_topics() {
+            let events = Events::new(false);
+            let topic = [0x42; 32];
+            events.emit_anonymous_events(topic);
+
+            let emitted_events = ink::env::test::recorded_events().collect::<Vec<_>>();
+            assert_eq!(2, emitted_events.len());
+
+            let event = &emitted_events[0];
+            assert_eq!(event.topics.len(), 1);
+            assert_eq!(event.topics[0], topic);
+
+            let event = &emitted_events[1];
+            assert_eq!(event.topics.len(), 1);
+            assert_eq!(event.topics[0], topic);
+
+            let signature_topic =
+                <InlineAnonymousEvent as ink::env::Event>::SIGNATURE_TOPIC;
+            assert_eq!(None, signature_topic);
+        }
+    }
+
+    #[cfg(all(test, feature = "e2e-tests"))]
+    mod e2e_tests {
+        use super::*;
+        use ink_e2e::{
+            ContractsBackend,
+            H256,
+        };
+
+        type E2EResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+        #[ink_e2e::test]
+        async fn emits_foreign_event<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let init_value = false;
+            let mut constructor = EventsRef::new(init_value);
+            let contract = client
+                .instantiate("events", &ink_e2e::alice(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Events>();
+
+            // when
+            let flip = call_builder.flip_with_foreign_event();
+            let flip_res = client
+                .call(&ink_e2e::bob(), &flip)
+                .submit()
+                .await
+                .expect("flip failed");
+
+            let contract_events = flip_res.contract_emitted_events()?;
+
+            // then
+            assert_eq!(1, contract_events.len());
+            let contract_event = &contract_events[0];
+            let flipped: event_def::ForeignFlipped =
+                ink::scale::Decode::decode(&mut &contract_event.event.data[..])
+                    .expect("encountered invalid contract event data buffer");
+            assert_eq!(!init_value, flipped.value);
+
+            let signature_topic =
+                <event_def::ForeignFlipped as ink::env::Event>::SIGNATURE_TOPIC
+                    .map(H256::from)
+                    .unwrap();
+
+            let expected_topics = vec![signature_topic];
+            assert_eq!(expected_topics, contract_event.topics);
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn emits_inline_event<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let init_value = false;
+            let mut constructor = EventsRef::new(init_value);
+            let contract = client
+                .instantiate("events", &ink_e2e::alice(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Events>();
+
+            // when
+            let flip = call_builder.flip_with_inline_event();
+            let flip_res = client
+                .call(&ink_e2e::bob(), &flip)
+                .submit()
+                .await
+                .expect("flip failed");
+
+            let contract_events = flip_res.contract_emitted_events()?;
+
+            // then
+            assert_eq!(1, contract_events.len());
+            let contract_event = &contract_events[0];
+            let flipped: InlineFlipped =
+                ink::scale::Decode::decode(&mut &contract_event.event.data[..])
+                    .expect("encountered invalid contract event data buffer");
+            assert_eq!(!init_value, flipped.value);
+
+            let signature_topic = <InlineFlipped as ink::env::Event>::SIGNATURE_TOPIC
+                .map(H256::from)
+                .unwrap();
+
+            let expected_topics = vec![signature_topic];
+            assert_eq!(expected_topics, contract_event.topics);
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn emits_event_with_option_topic_none<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let init_value = false;
+            let mut constructor = EventsRef::new(init_value);
+            let contract = client
+                .instantiate("events", &ink_e2e::alice(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let call_builder = contract.call_builder::<Events>();
+
+            // when
+            let call = call_builder.emit_32_byte_topic_event(None);
+            let call_res = client
+                .call(&ink_e2e::bob(), &call)
+                .submit()
+                .await
+                .expect("emit_32_byte_topic_event failed");
+
+            let contract_events = call_res.contract_emitted_events()?;
+
+            // then
+            assert_eq!(1, contract_events.len());
+            let contract_event = &contract_events[0];
+            let event: event_def::ThirtyTwoByteTopics =
+                ink::scale::Decode::decode(&mut &contract_event.event.data[..])
+                    .expect("encountered invalid contract event data buffer");
+            assert!(event.maybe_hash.is_none());
+
+            let signature_topic =
+                <event_def::ThirtyTwoByteTopics as ink::env::Event>::SIGNATURE_TOPIC
+                    .map(H256::from)
+                    .unwrap();
+
+            let expected_topics = vec![
+                signature_topic,
+                [0x42; 32].into(),
+                [0x00; 32].into(), // None is encoded as 0x00
+            ];
+            assert_eq!(expected_topics, contract_event.topics);
+
+            Ok(())
+        }
+
+        #[ink_e2e::test]
+        async fn emits_custom_signature_event<Client: E2EBackend>(
+            mut client: Client,
+        ) -> E2EResult<()> {
+            // given
+            let init_value = false;
+            let mut constructor = EventsRef::new(init_value);
+            let contract = client
+                .instantiate("events", &ink_e2e::alice(), &mut constructor)
+                .submit()
+                .await
+                .expect("instantiate failed");
+            let mut call_builder = contract.call_builder::<Events>();
+
+            // when
+            let call = call_builder.flip_with_inline_custom_event();
+            let call_res = client
+                .call(&ink_e2e::bob(), &call)
+                .submit()
+                .await
+                .expect("flip_with_inline_custom_event failed");
+
+            let contract_events = call_res.contract_emitted_events()?;
+
+            // then
+            assert_eq!(1, contract_events.len());
+
+            let signature_topic =
+                <InlineCustomFlipped as ink::env::Event>::SIGNATURE_TOPIC;
+
+            assert_eq!(Some([17u8; 32]), signature_topic);
+
+            Ok(())
+        }
+    }
+}

--- a/flipper/Cargo.toml
+++ b/flipper/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "flipper"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 hex = { version = "0.4.3" }
 
 [lib]

--- a/incrementer/Cargo.toml
+++ b/incrementer/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/lazyvec/Cargo.toml
+++ b/lazyvec/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "lazyvec-integration-tests"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/mapping/Cargo.toml
+++ b/mapping/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "mapping-integration-tests"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/multi-contract-caller/Cargo.toml
+++ b/multi-contract-caller/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "multi-contract-caller"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 adder = { path = "adder", default-features = false, features = ["ink-as-dependency"] }
 subber = { path = "subber", default-features = false, features = ["ink-as-dependency"] }
 accumulator = { path = "accumulator", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/multi-contract-caller/accumulator/Cargo.toml
+++ b/multi-contract-caller/accumulator/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "accumulator"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 [lib]
 path = "lib.rs"
 

--- a/multi-contract-caller/adder/Cargo.toml
+++ b/multi-contract-caller/adder/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "adder"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 

--- a/multi-contract-caller/subber/Cargo.toml
+++ b/multi-contract-caller/subber/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "subber"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 accumulator = { path = "../accumulator", default-features = false, features = ["ink-as-dependency"] }
 

--- a/multisig/Cargo.toml
+++ b/multisig/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "multisig"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/payment-channel/Cargo.toml
+++ b/payment-channel/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "payment_channel"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
 hex-literal = { version = "0.4.1" }

--- a/psp22-extension/Cargo.toml
+++ b/psp22-extension/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "psp22_extension"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/rand-extension/Cargo.toml
+++ b/rand-extension/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rand_extension"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/static-buffer/Cargo.toml
+++ b/static-buffer/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "static-buffer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/trait-dyn-cross-contract-calls/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "trait-incrementer-caller"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 dyn-traits = { path = "./traits", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 trait-incrementer = { path = "./contracts/incrementer", default-features = false, features = ["ink-as-dependency"] }
 
 [lib]

--- a/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/contracts/incrementer/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "trait-incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 dyn-traits = { path = "../../traits", default-features = false }
 

--- a/trait-dyn-cross-contract-calls/traits/Cargo.toml
+++ b/trait-dyn-cross-contract-calls/traits/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "dyn-traits"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/trait-erc20/Cargo.toml
+++ b/trait-erc20/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "trait_erc20"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/trait-flipper/Cargo.toml
+++ b/trait-flipper/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "trait_flipper"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/trait-incrementer/Cargo.toml
+++ b/trait-incrementer/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "trait-incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 traits = { path = "./traits", default-features = false }
 

--- a/trait-incrementer/traits/Cargo.toml
+++ b/trait-incrementer/traits/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "traits"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 name = "traits"

--- a/upgradeable-contracts/delegator/Cargo.toml
+++ b/upgradeable-contracts/delegator/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "delegator"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 delegatee = { path = "delegatee", default-features = false, features = ["ink-as-dependency"] }
 delegatee2 = { path = "delegatee2", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/delegator/delegatee/Cargo.toml
+++ b/upgradeable-contracts/delegator/delegatee/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "delegatee"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/delegator/delegatee2/Cargo.toml
+++ b/upgradeable-contracts/delegator/delegatee2/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "delegatee2"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash-migration/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash-migration/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 migration = { path = "./migration", default-features = false, features = ["ink-as-dependency"] }
 updated-incrementer = { path = "./updated-incrementer", default-features = false, features = ["ink-as-dependency"] }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash-migration/migration/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash-migration/migration/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "migration"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash-migration/updated-incrementer/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash-migration/updated-incrementer/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "updated-incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/upgradeable-contracts/set-code-hash/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 updated-incrementer = { path = "updated-incrementer", default-features = false, features = ["ink-as-dependency"] }
 
 [lib]

--- a/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
+++ b/upgradeable-contracts/set-code-hash/updated-incrementer/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "updated-incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [lib]
 path = "lib.rs"

--- a/vesting/Cargo.toml
+++ b/vesting/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "vesting"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
 

--- a/wildcard-selector/Cargo.toml
+++ b/wildcard-selector/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "wildcard-selector"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false
 
 [dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
+ink = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.0.0-rc.2" }
+ink_e2e = { version = "5.0.0" }
 
 [lib]
 path = "lib.rs"

--- a/workspace-contracts/Cargo.toml
+++ b/workspace-contracts/Cargo.toml
@@ -4,5 +4,5 @@ exclude = [".cargo", "target"]
 resolver = "2"
 
 [workspace.dependencies]
-ink = { version = "5.0.0-rc.2", default-features = false }
-ink_e2e = "5.0.0-rc.2"
+ink = { version = "5.0.0", default-features = false }
+ink_e2e = "5.0.0"

--- a/workspace-contracts/flipper/Cargo.toml
+++ b/workspace-contracts/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false

--- a/workspace-contracts/incrementer/Cargo.toml
+++ b/workspace-contracts/incrementer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incrementer"
-version = "5.0.0-rc.2"
+version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 publish = false


### PR DESCRIPTION
Update to ink5!
Add `events` and `e2e-runtime-only-backend` examples